### PR TITLE
Typo in docs (probably referring to an old version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can also change more advanced options such as mail binary (by default uses `
 1. Install markdown `apt install python-markdown`. You can skip this step since the script will check and install it for you.
 2. Download config file and script, then place wherever you prefer e.g. `/usr/sbin/snapraid`
 3. Give executable rights to the main script - `chmod +x snapraid-aio-script.sh`
-4. Edit the config file and add your email address at line 43
+4. Edit the config file and add your email address at line 9
 5. Tweak the config file if needed
 6. Schedule the script execution time
 


### PR DESCRIPTION
Hi there,

Was reading through your documentation and noticed there is something weird here.
Line 43 is referring to the verbosity of the email output, which can only be 1 or 0.
Thought probably you moved some stuff in the config file and probably the docs is still referring to line 43 for the previous version of the file.
Guess it's gonna be line 9 now.