### PR TITLE
Merge code for 2.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,30 @@ _This readme has some rough edges which will be smoothened over time._
 - One of the following will happen:     
     - If parity info is out of sync **and** the number of deleted or changed files exceed the threshold you have configured it **stops**. You may want to take a look to the output log.
     - If parity info is out of sync **and** the number of deleted or changed files exceed the threshold, you can still **force a sync** after a number of warnings. It's useful If  you often get a false alarm but you're confident enough. This is called "Sync with threshold warnings"
-    - If parity info is out of sync **but** the number of deleted or changed files did not exceed the treshold, it **executes a sync** to update the parity info.
+    - If parity info is out of sync **but** the number of deleted or changed files did not exceed the threshold, it **executes a sync** to update the parity info.
 - When the parity info is in sync, either because nothing has changed or after a successfully sync, it runs the `snapraid scrub` command to validate the integrity of the data, both the files and the parity info. If sync was cancelled or other issues were found, scrub will not be run. _Note that each run of the scrub command will validate only a configurable portion of parity info to avoid having a long running job and affecting the performance of the server._
 - Extra information is be added, like SnapRAID's disk health report.  
 - When the script is done sends an email with the results, both in case of error or success.
 
 ## Customization
-Many options can be changed to your taste, their behaviour is documented in the script config file.
+Many options can be changed to your taste, their behavior is documented in the script config file.
+If you don't know what to do, I recommend using the default values and see how it performs.
 
-Pre-hashing is enabled by default to avoid silent read errors. It mitigates the lack of ECC memory.
-
-If you don't know what to do, I recommend using the default values and see how it performs. 
+### Customizable features
+- Sync options
+	- Sync always (forced sync)
+	- Sync after a number of breached threshold warnings 
+	- Sync only if thresholds warnings are not breached (enabled by default)
+	- Thresholds for deleted and updated files	
+- Scrub options 
+	- Enable or disable scrub
+	- Data to be scrubbed - by default 5% older than 10 days
+- Pre-hashing - enabled by default to avoid silent read errors. It mitigates the lack of ECC memory.
+- SMART Log - enabled by default, a SnapRAID report for disks health status
+- Verbosity - disabled by default, does not include the TOUCH and DIFF output to have a better email
+- Spindown - to spindown drives after the script, disabled because is currently not working 
+- Snapraid Status - show the status of the array, disabled because the report output is not rendered correctly 
+ 
 
 You can also change more advanced options such as mail binary (by default uses `mailx`), SnapRAID binary location, log file location.
 
@@ -38,8 +51,6 @@ You can also change more advanced options such as mail binary (by default uses `
 This report produces emails that don't contain a list of changed files to improve clarity.
 
 You can re-enable full output in the email by switching the option `VERBOSITY` but the full report will always be available in `/tmp/snapRAID.out` but will be replaced after each run, or deleted when the system is shut down. You can change the location of the file, if needed.
-
-SMART drive report from SnapRAID is also included by default.
 
 Here's a sneak peek of the email report.
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ _This readme has some rough edges which will be smoothened over time._
 # Highlights
 
 ## How it works
-- After some preliminary checks, the script will execute `snapraid diff` to figure out if parity info is out of date, which means checking for changes since the last execution.
+- After some preliminary checks, the script will execute `snapraid diff` to figure out if parity info is out of date, which means checking for changes since the last execution. During this step, the script will ensure drives are fine by reading parity and content files. 
 - One of the following will happen:     
     - If parity info is out of sync **and** the number of deleted or changed files exceed the threshold you have configured it **stops**. You may want to take a look to the output log.
-    - If parity info is out of sync **and** the number of deleted or changed files exceed the threshold, you can still **force a sync** after a number of warnings. It's useful If  you often get a false alarm but you're confident enough.
+    - If parity info is out of sync **and** the number of deleted or changed files exceed the threshold, you can still **force a sync** after a number of warnings. It's useful If  you often get a false alarm but you're confident enough. This is called "Sync with threshold warnings"
     - If parity info is out of sync **but** the number of deleted or changed files did not exceed the treshold, it **executes a sync** to update the parity info.
-- When the parity info is in sync, either because nothing has changed or after a successfully sync, it runs the `snapraid scrub` command to validate the integrity of the data, both the files and the parity info. _Note that each run of the scrub command will validate only a configurable portion of parity info to avoid having a long running job and affecting the performance of the server._
+- When the parity info is in sync, either because nothing has changed or after a successfully sync, it runs the `snapraid scrub` command to validate the integrity of the data, both the files and the parity info. If sync was cancelled or other issues were found, scrub will not be run. _Note that each run of the scrub command will validate only a configurable portion of parity info to avoid having a long running job and affecting the performance of the server._
+- Extra information is be added, like SnapRAID's disk health report.  
 - When the script is done sends an email with the results, both in case of error or success.
 
 Pre-hashing is enabled by default to avoid silent read errors. It mitigates the lack of ECC memory.
@@ -29,7 +30,7 @@ Pre-hashing is enabled by default to avoid silent read errors. It mitigates the 
 ## A nice email report
 This report produces emails that don't contain a list of changed files to improve clarity.
 
-You can re-enable full output in the email by switching the option `VERBOSITY` but the full report will always be available in `/tmp/snapRAID.out` and will be replaced after each run or deleted when the system is shut down if kept there.
+You can re-enable full output in the email by switching the option `VERBOSITY` but the full report will always be available in `/tmp/snapRAID.out` but will be replaced after each run, or deleted when the system is shut down. You can change the location of the file, if needed.
 
 SMART drive report from SnapRAID is also included by default.
 
@@ -66,8 +67,9 @@ DIFF finished [Sat Jan 9 02:07:46 CET 2021]
 
 **SUMMARY of changes - Added [2] - Deleted [0] - Moved [0] - Copied [0] - Updated [0]**
 
-There are deleted files. The number of deleted files, (0), is below the threshold of (2). SYNC Authorized.  
-There are updated files. The number of updated files, (0), is below the threshold of (2). SYNC Authorized.
+There are no deleted files, that's fine.
+There are no updated files, that's fine.
+SYNC is authorized.
 
 ### SnapRAID SYNC [Sat Jan 9 02:07:46 CET 2021]
 
@@ -166,7 +168,7 @@ You can also change more advanced options such as mail binary (by default uses `
 
 
 # Requirements
-- Markdown to have nice emails
+- Markdown to have nice emails - will be installed if not found
 - ~~Hd-idle to spin down disks - [Link TBD] - currently not required since spin down does not work properly.~~
 
 # Installation
@@ -176,6 +178,8 @@ You can also change more advanced options such as mail binary (by default uses `
 4. Edit the config file and add your email address at line 9
 5. Tweak the config file if needed
 6. Schedule the script execution time
+
+It is tested on OMV5, but will work on other distros. In such case you may have to change the mail binary or SnapRAID location.
 
 # Known Issues
 - Hard disk spin down does not work: they are immediately woken up. The script probably does not handle this correctly while running.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ _This readme has some rough edges which will be smoothened over time._
 - Extra information is be added, like SnapRAID's disk health report.  
 - When the script is done sends an email with the results, both in case of error or success.
 
+## Customization
+Many options can be changed to your taste, their behaviour is documented in the script config file.
+
 Pre-hashing is enabled by default to avoid silent read errors. It mitigates the lack of ECC memory.
+
+If you don't know what to do, I recommend using the default values and see how it performs. 
+
+You can also change more advanced options such as mail binary (by default uses `mailx`), SnapRAID binary location, log file location.
 
 ## A nice email report
 This report produces emails that don't contain a list of changed files to improve clarity.
@@ -158,14 +165,6 @@ Probability that at least one disk is going to fail in the next year is 0%.
 All jobs ended. [Sat Jan 9 02:07:49 CET 2021]  
 Email address is set. Sending email report to example@example.com [Sat Jan 9 02:07:49 CET 2021]
 ```
-
-## Customization
-Many options can be changed to your taste, their behaviour is documented in the script config file.
-
-If you don't know what to do, I recommend using the default values and see how it performs. 
-
-You can also change more advanced options such as mail binary (by default uses `mailx`), SnapRAID binary location, log file location.
-
 
 # Requirements
 - Markdown to have nice emails - will be installed if not found

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Email address is set. Sending email report to example@example.com [Sat Jan 9 02:
 
 It is tested on OMV5, but will work on other distros. In such case you may have to change the mail binary or SnapRAID location.
 
+If you want to use this script on OMV, don't worry about the section _Diff Script Settings_ in the main page of the SnapRAID plugin, since it only applies to the built-in plugin script. Also don't forget to remove from scheduling the built-in script.
+
 # Known Issues
 - Hard disk spin down does not work: they are immediately woken up. The script probably does not handle this correctly while running.
 - The report is not perfect, we can't be solve this because SnapRAID does not natively support Markdown. 

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -3,7 +3,7 @@
 #
 #   Project page: https://github.com/auanasgheps/snapraid-aio-script
 #
-SNAPSCRIPTVERSION="2.7"
+SNAPSCRIPTVERSION="2.7.0.1-DEV1"
 ########################################################################
 
 ######################
@@ -203,6 +203,7 @@ function main(){
   # Show SnapRAID Status information if enabled
   if [ $SNAP_STATUS -eq 1 ]; then
     echo
+    echo "###SnapRAID Status"
     $SNAPRAID_BIN status
     close_output_and_wait
     output_to_file_screen

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -8,7 +8,7 @@
 ######################
 #   CONFIG VARIABLES #
 ######################
-SNAPSCRIPTVERSION="2.7.0.1-DEV7"
+SNAPSCRIPTVERSION="2.8"
 
 # find the current path
 CURRENT_DIR="$(dirname "${0}")"

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -8,7 +8,7 @@
 ######################
 #   CONFIG VARIABLES #
 ######################
-SNAPSCRIPTVERSION="2.7.0.1-DEV6"
+SNAPSCRIPTVERSION="2.7.0.1-DEV7"
 
 # find the current path
 CURRENT_DIR="$(dirname "${0}")"

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -415,15 +415,6 @@ function chk_zero(){
   fi
 }
 
-function service_array_setup() {
-  if [ -z "$SERVICES" ]; then
-    echo "Please configure services"
-  else
-    echo "Setting up service array"
-    read -a service_array <<<$SERVICES
-  fi
-}
-
 function prepare_mail() {
   if [ $CHK_FAIL -eq 1 ]; then
     if [ $DEL_COUNT -ge $DEL_THRESHOLD -a $DO_SYNC -eq 0 ]; then

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -234,7 +234,7 @@ function main(){
   #   do
   #     if [[ `smartctl -a /dev/$DRIVE | grep 'Rotation Rate' | grep rpm` ]]; then
   #       echo "spinning down /dev/$DRIVE"
-  #       hd-idle -t $DRIVE
+  #       hd-idle -t /dev/$DRIVE
   #     fi
   #   done
   # fi

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -8,7 +8,7 @@
 ######################
 #   CONFIG VARIABLES #
 ######################
-SNAPSCRIPTVERSION="2.7.0.1-DEV4"
+SNAPSCRIPTVERSION="2.7.0.1-DEV6"
 
 # find the current path
 CURRENT_DIR="$(dirname "${0}")"
@@ -129,7 +129,7 @@ function main(){
 
   # Now run sync if conditions are met
   if [ $DO_SYNC -eq 1 ]; then
-    echo "SYNC is authorized."
+    echo "SYNC is authorized. [`date`]"
     echo "###SnapRAID SYNC [`date`]"
   mklog "INFO: SnapRAID SYNC Job started"
   if [ $PREHASH -eq 1 ]; then
@@ -263,8 +263,6 @@ function main(){
   fi
   fi
 
-  #clean_desc
-
   exit 0;
 }
 
@@ -358,7 +356,7 @@ function chk_updated(){
 function chk_sync_warn(){
   if [ $SYNC_WARN_THRESHOLD -gt -1 ]; then
 	if [ $SYNC_WARN_THRESHOLD -eq 0 ]; then
-	echo "Forced sync is enabled. [`date`]"
+	echo "Forced sync is enabled."
   mklog "INFO: Forced sync is enabled."
 	else 
 	echo "Sync after threshold warning(s) is enabled."
@@ -374,7 +372,7 @@ function chk_sync_warn(){
 	  DO_SYNC=1
 	  else
       # if there is at least one warn count, output a message and force a sync job. Do not need to remove warning marker here as it is automatically removed when the sync job is run by this script
-      echo "Number of threshold warning(s) ($SYNC_WARN_COUNT) has reached/exceeded threshold ($SYNC_WARN_THRESHOLD). Forcing a SYNC job to run. [`date`]"
+      echo "Number of threshold warning(s) ($SYNC_WARN_COUNT) has reached/exceeded threshold ($SYNC_WARN_THRESHOLD). Forcing a SYNC job to run."
     mklog "INFO: Number of threshold warning(s) ($SYNC_WARN_COUNT) has reached/exceeded threshold ($SYNC_WARN_THRESHOLD). Forcing a SYNC job to run." 
       DO_SYNC=1
 	  fi
@@ -424,14 +422,6 @@ function service_array_setup() {
     echo "Setting up service array"
     read -a service_array <<<$SERVICES
   fi
-}
-
-function clean_desc(){
-  # Cleanup file descriptors
-  exec >&{out} 2>&{err}
- 
-  # If interactive shell restore output
-  [[ $- == *i* ]] && exec &>/dev/tty
 }
 
 function prepare_mail() {


### PR DESCRIPTION
- Added a title for the _SnapRAID Status_ section.
- Changed strings when the output is 0. This nonsense is gone:
         -  _The number of deleted/updated files, (0), is below the threshold_
         -  _The number of threshold warning(s) (0) has reached/exceeded threshold (0)_
         -  _0 threshold warning(s) until the next forced sync_
- Added a string when using _Sync with threshold warning_ - before was only shown "Forced Sync"
- Moved "Sync is authorized" message for more clarity
- Minor tweaks to other messages
- Removed `clean_desc` and `service_array_setup` functions, used for container management