### PR TITLE
Fix indentation and shellcheck

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -28,7 +28,7 @@ SYNC_WARN_THRESHOLD=-1
 SCRUB_PERCENT=5
 SCRUB_AGE=10
 
-# Set number of script runs before running a scrub. Use this option if you 
+# Set number of script runs before running a scrub. Use this option if you
 # don't want to scrub the array every time.
 # Set to 0 to disable this option and run scrub every time.
 SCRUB_DELAYED_RUN=0

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -181,7 +181,7 @@ function main(){
         # Everything ok - ready to run the scrub job!
         # The fuction will check if scrub delayed run is enabled and run scrub
         # based on configured conditions
-		    chk_scrub_settings
+        chk_scrub_settings
       fi
     fi
   else
@@ -303,13 +303,13 @@ function sanity_check() {
 }
 
 function get_counts() {
-  EQ_COUNT=$(grep -w '^ \{1,\}[0-9]* equal' $TMP_OUTPUT | sed 's/^ *//g' | cut -d ' ' -f1)
+  # EQ_COUNT=$(grep -w '^ \{1,\}[0-9]* equal' $TMP_OUTPUT | sed 's/^ *//g' | cut -d ' ' -f1)
   ADD_COUNT=$(grep -w '^ \{1,\}[0-9]* added' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
   DEL_COUNT=$(grep -w '^ \{1,\}[0-9]* removed' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
   UPDATE_COUNT=$(grep -w '^ \{1,\}[0-9]* updated' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
   MOVE_COUNT=$(grep -w '^ \{1,\}[0-9]* moved' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
   COPY_COUNT=$(grep -w '^ \{1,\}[0-9]* copied' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  REST_COUNT=$(grep -w '^ \{1,\}[0-9]* restored' $TMP_OUTPUT | sed 's/^ *//g' | cut -d ' ' -f1)  
+  # REST_COUNT=$(grep -w '^ \{1,\}[0-9]* restored' $TMP_OUTPUT | sed 's/^ *//g' | cut -d ' ' -f1)
 }
 
 function sed_me(){
@@ -425,40 +425,40 @@ function chk_zero(){
 
 function chk_scrub_settings(){
 	if [ "$SCRUB_DELAYED_RUN" -gt 0 ]; then
-	  echo "Delayed scrub is enabled."
+    echo "Delayed scrub is enabled."
       mklog "INFO: Delayed scrub is enabled.."
-  	fi
-	
+    fi
+
 	local scrub_count
     scrub_count=$(sed '/^[0-9]*$/!d' "$SCRUB_COUNT_FILE" 2>/dev/null)
     # zero if file does not exist or did not contain a number
     : "${scrub_count:=0}"
-	
+
 	if [ "$scrub_count" -ge "$SCRUB_DELAYED_RUN" ]; then
-	  # Run a scrub job. if the warn count is zero it means the scrub was already 
-	  # forced, do not output a dumb message and continue with the scrub job.
-      if [ "$scrub_count" -eq 0 ]; then
-	  echo
-        run_scrub
-	  else
+    # Run a scrub job. if the warn count is zero it means the scrub was already
+    # forced, do not output a dumb message and continue with the scrub job.
+    if [ "$scrub_count" -eq 0 ]; then
+      echo
+      run_scrub
+    else
       # if there is at least one warn count, output a message and force a scrub
-	  # job. Do not need to remove warning marker here as it is automatically 
-	  # removed when the scrub job is run by this script
+      # job. Do not need to remove warning marker here as it is automatically
+      # removed when the scrub job is run by this script
       echo "Number of delayed runs has reached/exceeded threshold ($SCRUB_DELAYED_RUN). A SCRUB job will run."
-      mklog "INFO: Number of delayed runs has reached/exceeded threshold ($SCRUB_DELAYED_RUN). A SCRUB job will run." 
-	  echo
-		run_scrub
-	  fi
+      mklog "INFO: Number of delayed runs has reached/exceeded threshold ($SCRUB_DELAYED_RUN). A SCRUB job will run."
+      echo
+      run_scrub
+    fi
 	else
-      # NO, so let's increment the warning count and skip the scrub job
-      ((scrub_count += 1))
-      echo "$scrub_count" > "$SCRUB_COUNT_FILE"
-	  if [ "$scrub_count" == "$SCRUB_DELAYED_RUN" ]; then
-		 echo  "This is the **last** run left before running scrub job next time. [$(date)]"
-		 mklog "INFO: This is the **last** run left before running scrub job next time. [$(date)]"
-	  else 
-		 echo "$((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
-		 mklog "INFO: $((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
+    # NO, so let's increment the warning count and skip the scrub job
+    ((scrub_count += 1))
+    echo "$scrub_count" > "$SCRUB_COUNT_FILE"
+    if [ "$scrub_count" == "$SCRUB_DELAYED_RUN" ]; then
+      echo  "This is the **last** run left before running scrub job next time. [$(date)]"
+      mklog "INFO: This is the **last** run left before running scrub job next time. [$(date)]"
+    else
+      echo "$((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
+      mklog "INFO: $((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
     fi
 	fi
 }
@@ -472,15 +472,15 @@ function run_scrub(){
     mklog "INFO: SnapRAID SCRUB Job finished"
     echo
     JOBS_DONE="$JOBS_DONE + SCRUB"
-    # insert SCRUB marker to 'Everything OK' or 'Nothing to do' string to 
+    # insert SCRUB marker to 'Everything OK' or 'Nothing to do' string to
     # differentiate it from SCRUB job above
     sed_me "s/^Everything OK/**SCRUB JOB - Everything OK**/g;s/^Nothing to do/**SCRUB JOB - Nothing to do**/g" "$TMP_OUTPUT"
-	  # Remove the warning flag if set previously. This is done now to 
-	  # take care of scenarios when user has manually synced or restored
+    # Remove the warning flag if set previously. This is done now to
+    # take care of scenarios when user has manually synced or restored
     # deleted files and we will have missed it in the checks above.
-	  if [ -e "$SCRUB_COUNT_FILE" ]; then
-	   rm "$SCRUB_COUNT_FILE"
-	  fi
+    if [ -e "$SCRUB_COUNT_FILE" ]; then
+      rm "$SCRUB_COUNT_FILE"
+    fi
 }
 
 function prepare_mail() {


### PR DESCRIPTION
It looks like there are tabs being mixed into the file which make it really hard to read. (see the github diff output for example)

I usually use spaces, but if tabs is what you prefer that is fine too. Just better to pick one and not mix them together.

I also commented out the two unused variables to fix shellcheck warning. When you finish this feature you can uncomment them.