### PR TITLE
Healthchecks.io

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -58,8 +58,8 @@ SPINDOWN=0
 SNAP_STATUS=0
 
 # Use Healthchecks.io to report script errors. Set to 1 to enable.
-# Please note that every "WARNING" message will be reported as failure. 
-# When enabled, enter your Healthchecks UUID (not the full URL)
+# Please note that every "WARNING" will be reported as failure. 
+# When enabled, enter your Healthchecks UUID (not the full URL).
 HEALTHCHECKS=0
 HEALTHCHECKS_ID='your-uuid-here'
 

--- a/script-config.sh
+++ b/script-config.sh
@@ -57,6 +57,12 @@ SPINDOWN=0
 # HTML output is pretty broken.
 SNAP_STATUS=0
 
+# Use Healthchecks.io to report script errors. Set to 1 to enable.
+# Please note that every "WARNING" message will be reported as failure. 
+# When enabled, enter your Healthchecks UUID (not the full URL)
+HEALTHCHECKS=0
+HEALTHCHECKS_ID='your-uuid-here'
+
 # Set to 1 to manage docker containers. They will be paused/stopped or 
 # resumed/restarted accordingly.
 MANAGE_SERVICES=1

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -46,6 +46,12 @@ function main(){
 
   echo "## Preprocessing"
 
+  # Healthchecks.io start 
+  if [ "$HEALTHCHECKS" -eq 1 ]; then  
+   echo "Healthchecks.io integration is enabled, script status will be reported to the configured URL."
+   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID/start"
+  fi
+  
   # Check if script configuration file has been found
   if [ ! -f "$CONFIG_FILE" ]; then
     echo "Script configuration file not found! The script cannot be run! Please check and try again!"
@@ -616,17 +622,33 @@ function prepare_mail() {
       MSG="Sync forced with multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) and changed files ($UPDATE_COUNT) / ($UP_THRESHOLD)"
     fi
     SUBJECT="[WARNING] $MSG $EMAIL_SUBJECT_PREFIX"
+	healthchecks_warning
   elif [ -z "${JOBS_DONE##*"SYNC"*}" ] && ! grep -qw "$SYNC_MARKER" "$TMP_OUTPUT"; then
     # Sync ran but did not complete successfully so lets warn the user
     SUBJECT="[WARNING] SYNC job ran but did not complete successfully $EMAIL_SUBJECT_PREFIX"
+	healthchecks_warning
   elif [ -z "${JOBS_DONE##*"SCRUB"*}" ] && ! grep -qw "$SCRUB_MARKER" "$TMP_OUTPUT"; then
     # Scrub ran but did not complete successfully so lets warn the user
     SUBJECT="[WARNING] SCRUB job ran but did not complete successfully $EMAIL_SUBJECT_PREFIX"
+	healthchecks_warning
   else
     SUBJECT="[COMPLETED] $JOBS_DONE Jobs $EMAIL_SUBJECT_PREFIX"
+	healthchecks_success
   fi
 }
 
+function healthchecks_success(){
+  if [ "$HEALTHCHECKS" -eq 1 ]; then
+   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/0 --data-raw "$MSG"
+  fi
+  }
+  
+function healthchecks_warning(){
+  if [ "$HEALTHCHECKS" -eq 1 ]; then
+   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/fail --data-raw "$SUBJECT"
+  fi
+  }
+   
 # Trim the log file read from stdin.
 function trim_log(){
   sed '

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -8,7 +8,7 @@
 ######################
 #   CONFIG VARIABLES #
 ######################
-SNAPSCRIPTVERSION="2.9.DEV3"
+SNAPSCRIPTVERSION="2.9.DEV4"
 
 # find the current path
 CURRENT_DIR=$(dirname "${0}")
@@ -639,7 +639,7 @@ function prepare_mail() {
 
 function healthchecks_success(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/0 --data-raw "$MSG"
+   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/0 --data-raw "$SUBJECT"
   fi
   }
   

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -48,7 +48,7 @@ function main(){
 
   # Healthchecks.io start 
   if [ "$HEALTHCHECKS" -eq 1 ]; then  
-   echo "Healthchecks.io integration is enabled, script status will be reported to the configured URL."
+   echo "Healthchecks.io integration is enabled."
    curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID/start"
   fi
   


### PR DESCRIPTION
**Add Healthchecks.io integration.**

Use Healthchecks.io to report script failures. 
Any "WARNING" will be reported as failure (DOWN), otherwise "UP".
Error message is reported to Healthchecks.io as well.
