### PR TITLE
Update to allow script to manage docker containers on multiple remote hosts

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -54,6 +54,18 @@ SNAPRAID_BIN="/usr/bin/snapraid"
 # location of the mail program binary
 MAIL_BIN="/usr/bin/mailx"
 
+# Set to 1 to manage docker containers.
+MANAGE_SERVICES=0
+  
+# Containers to manage (separated with spaces).
+SERVICES='container1 container2 container3'  
+
+# Set to 1 if docker is running on remote machine, and enter Docker host machine IP.
+# Passwordless ssh access between snapRAID host and Docker host must be set up before running the script.
+DOCKER_REMOTE=0
+DOCKER_USER="sshusernamegoeshere"
+DOCKER_IP="127.0.0.1"
+
 ####################### USER CONFIGURATION END #######################
 
 ####################### SYSTEM CONFIGURATION #######################

--- a/script-config.sh
+++ b/script-config.sh
@@ -93,12 +93,14 @@ SERVICES='container1 container2 container3'
 # Manage docker containers running on a remote machine. Set to 1 to enable, 
 # then enter Docker host machine IP and SSH user. Passwordless ssh access 
 # between snapRAID host and Docker host must be set up.
+# Host machine and services must be defined as the following example: 
+# ('HOSTIP1:container1,container2,container3' 'HOSTIP2:container1,container2,container3,container4')
 # Delay is the number of seconds to wait before sending the next docker 
 # command to avoid errors. Tune to your system.
 DOCKER_REMOTE=0
 DOCKER_USER="sshusernamegoeshere"
-DOCKER_IP="127.0.0.1"
-DOCKER_DELAY=5
+DOCKER_HOST_SERVICES=('HOSTIP1:container1,container2,container3' 'HOSTIP2:container1,container2,container3,container4')
+DOCKER_DELAY=10
 
 ####################### USER CONFIGURATION END #######################
 
@@ -128,12 +130,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Extract info from SnapRAID config
 SNAPRAID_CONF_LINES=$(grep -E '^[^#;]' $SNAPRAID_CONF)
 
+IFS=$'\n' 
 # Build an array of content files
-IFS=$'\n' CONTENT_FILES=(
+CONTENT_FILES=(
 $(echo "$SNAPRAID_CONF_LINES" | grep snapraid.content | cut -d ' ' -f2)
 )
 
 # Build an array of parity all files...
-IFS=$'\n' PARITY_FILES=(
+PARITY_FILES=(
   $(echo "$SNAPRAID_CONF_LINES" | grep -E '^([2-6z]-)*parity' | cut -d ' ' -f2- | tr ',' '\n')
 )
+unset IFS

--- a/script-config.sh
+++ b/script-config.sh
@@ -82,18 +82,6 @@ DOCKER_REMOTE=0
 DOCKER_USER="sshusernamegoeshere"
 DOCKER_IP="127.0.0.1"
 
-# Set to 1 to manage docker containers.
-MANAGE_SERVICES=0
-  
-# Containers to manage (separated with spaces).
-SERVICES='container1 container2 container3'  
-
-# Set to 1 if docker is running on remote machine, and enter Docker host machine IP.
-# Passwordless ssh access between snapRAID host and Docker host must be set up before running the script.
-DOCKER_REMOTE=0
-DOCKER_USER="sshusernamegoeshere"
-DOCKER_IP="127.0.0.1"
-
 ####################### USER CONFIGURATION END #######################
 
 ####################### SYSTEM CONFIGURATION #######################

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -69,12 +69,12 @@ function main(){
   mklog "INFO: Checking SnapRAID disks"
   sanity_check
 
-  # Pause any services that may inhibit optimum execution
+  # Stop any services that may inhibit optimum execution
   if [ $MANAGE_SERVICES -eq 1 ]; then
     service_array_setup
     echo
-    echo "###Pause Services [`date`]"
-    pause_services
+    echo "###Stop Services [`date`]"
+    stop_services
   fi
 
   echo
@@ -245,11 +245,11 @@ function main(){
   #   done
   # fi
 
-  # Resume paused services
+  # Restart stopped services
   if [ $MANAGE_SERVICES -eq 1 ]; then
     echo
-    echo "###Resume Services [`date`]"
-    resume_services
+    echo "###Restart Services [`date`]"
+    start_services
   fi
   
   echo "All jobs ended. [`date`]"
@@ -437,7 +437,7 @@ function service_array_setup() {
   fi
 }
 
-function pause_services(){
+function stop_services(){
   for i in ${service_array[@]}; do
     echo "Stopping Service - ""${i^}";
     if [ $DOCKER_REMOTE -eq 1 ]; then
@@ -445,11 +445,11 @@ function pause_services(){
     else
       docker stop $i
     fi
-	close_output_and_wait
+    close_output_and_wait
   done
 }
 
-function resume_services(){
+function start_services(){
   for i in ${service_array[@]}; do
     echo "Starting Service - ""${i^}";
     if [ $DOCKER_REMOTE -eq 1 ]; then
@@ -457,7 +457,7 @@ function resume_services(){
     else
       docker start $i
     fi
-	close_output_and_wait
+    close_output_and_wait
   done
 }
   

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -439,23 +439,25 @@ function service_array_setup() {
 
 function pause_services(){
   for i in ${service_array[@]}; do
-    echo "Pausing Service - ""${i^}";
+    echo "Stopping Service - ""${i^}";
     if [ $DOCKER_REMOTE -eq 1 ]; then
-      ssh $DOCKER_USER@$DOCKER_IP docker pause $i
+      ssh $DOCKER_USER@$DOCKER_IP docker stop $i
     else
-      docker pause $i
+      docker stop $i
     fi
+	close_output_and_wait
   done
 }
 
 function resume_services(){
   for i in ${service_array[@]}; do
-    echo "Resuming Service - ""${i^}";
+    echo "Starting Service - ""${i^}";
     if [ $DOCKER_REMOTE -eq 1 ]; then
-      ssh $DOCKER_USER@$DOCKER_IP docker unpause $i
+      ssh $DOCKER_USER@$DOCKER_IP docker start $i
     else
-      docker unpause $i
+      docker start $i
     fi
+	close_output_and_wait
   done
 }
   

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -448,14 +448,15 @@ function start_services(){
   if [ -z "$SERVICES" ]; then
     echo "Please configure services"
   else 
-  for i in ${service_array[@]}; do
-    echo "Starting Service - ""${i^}";
-    if [ $DOCKER_REMOTE -eq 1 ]; then
-      ssh $DOCKER_USER@$DOCKER_IP docker start $i
-    else
-      docker start $i
-    fi
-  done
+    for i in ${service_array[@]}; do
+      echo "Starting Service - ""${i^}";
+      if [ $DOCKER_REMOTE -eq 1 ]; then
+        ssh $DOCKER_USER@$DOCKER_IP docker start $i
+      else
+        docker start $i
+      fi
+    done
+  fi
 }
   
 function prepare_mail() {

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -247,6 +247,8 @@ function main(){
 
   # Resume paused services
   if [ $MANAGE_SERVICES -eq 1 ]; then
+    echo
+    echo "###Resume Services [`date`]"
     resume_services
   fi
   
@@ -448,7 +450,7 @@ function pause_services(){
 
 function resume_services(){
   for i in ${service_array[@]}; do
-    echo "Unpausing Service - ""${i^}";
+    echo "Resuming Service - ""${i^}";
     if [ $DOCKER_REMOTE -eq 1 ]; then
       ssh $DOCKER_USER@$DOCKER_IP docker unpause $i
     else


### PR DESCRIPTION
I made some updates to the way remote hosts are handled to allow management across multiple IP addresses. I had to change a few things in the way `IFS` was used in the config file to allow this to work. This is working to pause containers on three machines I have docker services on.