### PR TITLE
Add switch to enable sync based on ratio of added to deleted files

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -53,9 +53,9 @@ DEL_THRESHOLD=500
 UP_THRESHOLD=500
 # Allow a sync that would otherwise violate the delete threshold but only 
 # if the ratio of added to deleted files is greater than the value set. 
-# Set to 0 to bypass this option.
+# Set to 0 to disable this option.
 # Example: A senario with 5000 deleted files and 3800 added files would 
-# result in an ADD_DEL_RATIO of 0.76 (3800/5000) 
+# result in an ADD_DEL_THRESHOLD of 0.76 (3800/5000) 
 ADD_DEL_RATIO=0
 
 # Set number of warnings before we force a sync job. This option comes in handy

--- a/script-config.sh
+++ b/script-config.sh
@@ -51,6 +51,12 @@ HOOK_NOTIFICATION=""
 # do lots of manual syncing.
 DEL_THRESHOLD=500
 UP_THRESHOLD=500
+# Allow a sync that would otherwise violate the delete threshold but only 
+# if the ratio of added to deleted files is greater than the value set. 
+# Set to 0 to bypass this option.
+# Example: A senario with 5000 deleted files and 3800 added files would 
+# result in an ADD_DEL_RATIO of 0.76 (3800/5000) 
+ADD_DEL_RATIO=0
 
 # Set number of warnings before we force a sync job. This option comes in handy
 # when you cannot be bothered to manually start a sync job when DEL_THRESHOLD

--- a/script-config.sh
+++ b/script-config.sh
@@ -45,18 +45,18 @@ HOOK_NOTIFICATION=""
 
 ### SCRIPT AND SNAPRAID SETTINGS ###
 
-# Set the threshold of deleted files to stop the sync job from running. Note
-# that depending on how active your filesystem is being used, a low number here
-# may result in your parity info being out of sync often and/or you having to
-# do lots of manual syncing.
+# Set the threshold of deleted and updated files to stop the sync job from running. 
+# Note that depending on how active your filesystem is being used, a low number
+# here may result in your parity info being out of sync often and/or you having
+# to do lots of manual syncing.
 DEL_THRESHOLD=500
 UP_THRESHOLD=500
-# Allow a sync that would otherwise violate the delete threshold but only 
+# Allow a sync that would otherwise violate the delete threshold, but only
 # if the ratio of added to deleted files is greater than the value set. 
 # Set to 0 to disable this option.
 # Example: A senario with 5000 deleted files and 3800 added files would 
 # result in an ADD_DEL_THRESHOLD of 0.76 (3800/5000) 
-ADD_DEL_RATIO=0
+ADD_DEL_THRESHOLD=0
 
 # Set number of warnings before we force a sync job. This option comes in handy
 # when you cannot be bothered to manually start a sync job when DEL_THRESHOLD

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -431,6 +431,16 @@ function chk_del(){
       echo "There are deleted files. The number of deleted files ($DEL_COUNT) is below the threshold of ($DEL_THRESHOLD)."
       DO_SYNC=1
     fi
+  else if [ "$ADD_DEL_RATIO" -gt 0 ]; then
+    if [ ("$ADD_COUNT" / "$DEL_COUNT") -gt "$ADD_DEL_RATIO" ]; then
+	  echo "There are deleted files. The number of deleted files ($DEL_COUNT) is above the threshold of ($DEL_THRESHOLD)"
+	  echo "but the add/delete ratio is above the threshold of ($ADD_DEL_RATIO)."
+      DO_SYNC=1
+	else
+	  echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete ratio ($ADD_DEL_RATIO) was not met."
+      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete ratio ($ADD_DEL_RATIO) was not met."
+      CHK_FAIL=1
+	fi
   else
     echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
     mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -431,16 +431,17 @@ function chk_del(){
       echo "There are deleted files. The number of deleted files ($DEL_COUNT) is below the threshold of ($DEL_THRESHOLD)."
       DO_SYNC=1
     fi
-  else if [ "$ADD_DEL_RATIO" -gt 0 ]; then
-    if [ ("$ADD_COUNT" / "$DEL_COUNT") -gt "$ADD_DEL_RATIO" ]; then
-	  echo "There are deleted files. The number of deleted files ($DEL_COUNT) is above the threshold of ($DEL_THRESHOLD)"
-	  echo "but the add/delete ratio is above the threshold of ($ADD_DEL_RATIO)."
+  elif awk "BEGIN {exit !($ADD_DEL_THRESHOLD > 0)}"; then
+    ADD_DEL_RATIO="$(awk -v a=$ADD_COUNT -v b=$DEL_COUNT 'BEGIN {print ( a / b )}')"
+    if awk "BEGIN {exit !($ADD_DEL_RATIO >= $ADD_DEL_THRESHOLD)}"; then
+      echo "There are deleted files. The number of deleted files ($DEL_COUNT) is above the threshold of ($DEL_THRESHOLD)"
+      echo "but the add/delete ratio of ($ADD_DEL_RATIO) is above the threshold of ($ADD_DEL_THRESHOLD), sync will proceed."
       DO_SYNC=1
-	else
-	  echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete ratio ($ADD_DEL_RATIO) was not met."
-      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete ratio ($ADD_DEL_RATIO) was not met."
+    else 
+      echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete threshold ($ADD_DEL_THRESHOLD) was not met."
+      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete threshold ($ADD_DEL_THRESHOLD) was not met."
       CHK_FAIL=1
-	fi
+    fi
   else
     echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
     mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."


### PR DESCRIPTION
This allows a sync if the ratio of added to deleted files exceeds a user defined threshold, even if the delete threshold is exceeded. This is useful in the cases where files are being modified in a way that snapraid sees as adding and deleting rather than updating. Examples of this would be transcoding video files to different formats or a rolling backup service.