### PR TITLE
Add custom Healthchecks.io URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Email address is set. Sending email report to yourmail@example.com [Tue 20 Apr 1
 
 _Optional: install markdown `apt install python-markdown` and curl `apt install curl` . You can skip this step since the script will try to install missing packages for you._
 
-1. Download the latest version from [Releases](https://github.com/auanasgheps/snapraid-aio-script/releaseshttps://github.com/auanasgheps/snapraid-aio-script/releases) 
+1. Download the latest version from [Releases](https://github.com/auanasgheps/snapraid-aio-script/releases) 
 3. Extract the archive wherever you prefer 
    - e.g. `/usr/sbin/snapraid`
 4. Give executable rights to the main script 

--- a/script-config.sh
+++ b/script-config.sh
@@ -15,8 +15,11 @@ FROM_EMAIL_ADDRESS="fromemailgoeshere"
 # Use Healthchecks.io to report script errors. Set to 1 to enable.
 # Please note that every "WARNING" will be reported as failure.
 # When enabled, enter your Healthchecks UUID (not the full URL).
+# If using a self-hosted instance, change the URL to your endpoint                                                                                                      
+# including the trailing slash.
 HEALTHCHECKS=0
 HEALTHCHECKS_ID="your-uuid-here"
+HEALTHCHECKS_URL="https://hc-ping.com/"
 
 # Use Telegram to report script execution summary (not the whole report)
 # Set 1 to enable. Create a bot using @botfather, then copy the API token.

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -61,8 +61,8 @@ function main(){
    fi
    # invoke notification services if configured
     if [ "$HEALTHCHECKS" -eq 1 ]; then
-   echo "Healthchecks.io notification is enabled."
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/start
+   echo "Healthchecks.io notification is enabled. Notifications sent to $HEALTHCHECKS_URL."
+   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/start
    fi
     if [ "$TELEGRAM" -eq 1 ]; then
    echo "Telegram notification is enabled."
@@ -759,7 +759,7 @@ SUMMARY: Equal [$EQ_COUNT] - Added [$ADD_COUNT] - Deleted [$DEL_COUNT] - Moved [
 
 function notify_success(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/0 --data-raw "$NOTIFY_OUTPUT"
+   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/0 --data-raw "$NOTIFY_OUTPUT"
   fi
   if [ "$TELEGRAM" -eq 1 ]; then
    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
@@ -777,7 +777,7 @@ function notify_success(){
 
 function notify_warning(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/fail --data-raw "$NOTIFY_OUTPUT"
+   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/fail --data-raw "$NOTIFY_OUTPUT"
   fi
   if [ "$TELEGRAM" -eq 1 ]; then
    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -20,6 +20,9 @@ CONFIG_FILE=$CURRENT_DIR/script-config.sh
 #shellcheck source=script-config.sh
 source "$CONFIG_FILE"
 
+# set default variables for backward compatibility with older config files
+: ${HEALTHCHECKS_URL:="https://hc-ping.com/"}
+
 ########################################################################
 
 SYNC_MARKER="SYNC -"


### PR DESCRIPTION
Implements a custom healthchecks.io URL, along with the associated line in the script-config.sh file. However, to maintain backward compatibility, if the variable is not set in the config file, then the main script will set it to the sensible default.

Addresses issue 32: https://github.com/auanasgheps/snapraid-aio-script/issues/32