### PR TITLE
Updates to make docker management more efficient and versitile.

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -140,7 +140,7 @@ MANAGE_SERVICES=0
 # This option does not have any effect if MANAGE_SERVICES is set to 0
 DOCKER_MODE=1
 
-# Containers to manage (separated with spaces, commas, or colons). Please ensure these containers
+# Containers to manage (separated with spaces). Please ensure these containers
 # are always running before executing the script, otherwise an error will be logged.
 DOCKER_LOCAL=0
 SERVICES='container1 container2 container3'

--- a/script-config.sh
+++ b/script-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CONFIG_VERSION=3.2
+CONFIG_VERSION=3.3 #-DEV1
 ######################
 #   USER VARIABLES   #
 ######################
@@ -9,7 +9,7 @@ CONFIG_VERSION=3.2
 ### NOTIFICATION SETTINGS ###
 
 # Address where the output will be emailed to.
-# If you do not want to receive emails and rely on other notification 
+# If you do not want to receive emails and rely on other notification
 # methods, leave these fields empty.
 EMAIL_ADDRESS="destination-email-goes-here"
 FROM_EMAIL_ADDRESS="sender-email-goes-here"
@@ -17,8 +17,11 @@ FROM_EMAIL_ADDRESS="sender-email-goes-here"
 # Use Healthchecks.io to report script errors. Set to 1 to enable.
 # Please note that every "WARNING" will be reported as failure.
 # When enabled, enter your Healthchecks UUID (not the full URL).
+# If using a self-hosted instance, change the URL to your endpoint
+# including the trailing slash.
 HEALTHCHECKS=0
 HEALTHCHECKS_ID="your-uuid-here"
+HEALTHCHECKS_URL="https://hc-ping.com/"
 
 # Use Telegram to report script execution summary (not the whole report)
 # Set 1 to enable. Create a bot using @botfather, then copy the API token.
@@ -27,17 +30,17 @@ TELEGRAM=0
 TELEGRAM_TOKEN="your-token-here"
 TELEGRAM_CHAT_ID="your-chat-id-here"
 
-# Use Discord to report script execution summary (not the whole report) 
-# Set 1 to enable. 
-# To get your Webhook URL go to the channel settings -> Integrations and 
+# Use Discord to report script execution summary (not the whole report)
+# Set 1 to enable.
+# To get your Webhook URL go to the channel settings -> Integrations and
 # create a web hook
 DISCORD=0
 DISCORD_WEBHOOK_URL="your-webhook-url"
 
 # Custom notification service
-# Set this to a script/service to be used instead of the default email 
-# notification. You may want to use a service not natively supported by this 
-# script or a mail service with custom formatting. 
+# Set this to a script/service to be used instead of the default email
+# notification. You may want to use a service not natively supported by this
+# script or a mail service with custom formatting.
 # If you don't want to use this option, don't make changes to this.
 # $CURRENT_DIR can be used to get the running directory of the script.
 # This script will pass the following parameters to HOOK_NOTIFICATION:
@@ -47,7 +50,7 @@ HOOK_NOTIFICATION=""
 
 ### SCRIPT AND SNAPRAID SETTINGS ###
 
-# Set the threshold of deleted and updated files to stop the sync job from running. 
+# Set the threshold of deleted and updated files to stop the sync job from running.
 # Note that depending on how active your filesystem is being used, a low number
 # here may result in your parity info being out of sync often and/or you having
 # to do lots of manual syncing.
@@ -55,10 +58,10 @@ DEL_THRESHOLD=500
 UP_THRESHOLD=500
 
 # Allow a sync that would otherwise violate the delete threshold, but only
-# if the ratio of added to deleted files is greater than the value set. 
+# if the ratio of added to deleted files is greater than the value set.
 # Set to 0 to disable this option.
-# Example: A senario with 5000 deleted files and 3800 added files would 
-# result in an ADD_DEL_THRESHOLD of 0.76 (3800/5000) 
+# Example: A senario with 5000 deleted files and 3800 added files would
+# result in an ADD_DEL_THRESHOLD of 0.76 (3800/5000)
 ADD_DEL_THRESHOLD=0
 
 # Set number of warnings before we force a sync job. This option comes in handy
@@ -68,7 +71,7 @@ ADD_DEL_THRESHOLD=0
 # manual sync if delete threshold is breached).
 SYNC_WARN_THRESHOLD=-1
 
-# Set percentage of and age of blocks in array to scrub if it is in sync.
+# Set percentage and age, in days, of blocks in array to scrub if it is in sync.
 # i.e. 0 to disable and 100 to scrub the full array in one go.
 # WARNING - depending on size of your array, setting to 100 can take a long time!
 SCRUB_PERCENT=5
@@ -90,9 +93,9 @@ SCRUB_DELAYED_RUN=0
 # allow to run a fix operation. 1 to enable, any other value to disable.
 PREHASH=1
 
-# Forces the operation of syncing a file with zero size that before was not. 
+# Forces the operation of syncing a file with zero size that before was not.
 # If SnapRAID detects a such condition, it stops proceeding unless you enable
-# this option. Useful when syncing system files which can genuinely get 
+# this option. Useful when syncing system files which can genuinely get
 # changed to zero.
 # Disabled by default, 1 to enable.
 FORCE_ZERO=0
@@ -107,17 +110,17 @@ SPINDOWN=0
 SMART_LOG=1
 
 # Increase verbosity of the email output. NOT RECOMMENDED!
-# If set to 1, TOUCH and DIFF outputs will be kept in the email, producing 
+# If set to 1, TOUCH and DIFF outputs will be kept in the email, producing
 # a mostly unreadable email. You can always check TOUCH and DIFF outputs
 # using the TMP file or use the feature KEEP_LOG.
 # 1 to enable, any other value to disable.
 VERBOSITY=0
 
 # SnapRAID detailed output retention for each run.
-# Default behaviour is RETENTION_DAYS=0: every time your run SnapRAID, the 
+# Default behaviour is RETENTION_DAYS=0: every time your run SnapRAID, the
 # output is saved to "/tmp" and is overridden during every run.
-# To enable retention, set RETENTION_DAYS to the days of output you want to 
-# keep in your home folder. Files will have timestamps. 
+# To enable retention, set RETENTION_DAYS to the days of output you want to
+# keep in your home folder. Files will have timestamps.
 # SNAPRAID_LOG_DIR can be changed to any folder you like.
 RETENTION_DAYS=0
 SNAPRAID_LOG_DIR="$HOME"
@@ -139,7 +142,8 @@ DOCKER_MODE=1
 
 # Containers to manage (separated with spaces). Please ensure these containers
 # are always running before executing the script, otherwise an error will be logged.
-SERVICES='container1 container2 container3'
+DOCKER_LOCAL=0
+SERVICES='container1,container2,container3'
 
 # Manage docker containers running on a remote machine. To use this feature,
 # you must setup passwordless ssh access between snapRAID host and Docker host.

--- a/script-config.sh
+++ b/script-config.sh
@@ -112,7 +112,7 @@ SMART_LOG=1
 # Increase verbosity of the email output. NOT RECOMMENDED!
 # If set to 1, TOUCH and DIFF outputs will be kept in the email, producing
 # a mostly unreadable email. You can always check TOUCH and DIFF outputs
-# using the TMP file or use the feature KEEP_LOG.
+# using the TMP file or use the feature RETENTION_DAYS.
 # 1 to enable, any other value to disable.
 VERBOSITY=0
 
@@ -158,7 +158,7 @@ SERVICES='container1 container2 container3'
 DOCKER_REMOTE=0
 DOCKER_USER="sshusernamegoeshere"
 DOCKER_HOST_SERVICES=('HOSTIP1:container1 container2 container3' 'HOSTIP2:container1 container2 container3 container4')
-DOCKER_DELAY=10
+DOCKER_DELAY=0
 
 ### CUSTOM HOOKS ###
 

--- a/script-config.sh
+++ b/script-config.sh
@@ -17,7 +17,7 @@ FROM_EMAIL_ADDRESS="sender-email-goes-here"
 # Use Healthchecks.io to report script errors. Set to 1 to enable.
 # Please note that every "WARNING" will be reported as failure.
 # When enabled, enter your Healthchecks UUID (not the full URL).
-# If using a self-hosted instance, change the URL to your endpoint                                                                                                      
+# If using a self-hosted instance, change the URL to your endpoint
 # including the trailing slash.
 HEALTHCHECKS=0
 HEALTHCHECKS_ID="your-uuid-here"
@@ -143,23 +143,21 @@ DOCKER_MODE=1
 # Containers to manage (separated with spaces). Please ensure these containers
 # are always running before executing the script, otherwise an error will be logged.
 DOCKER_LOCAL=0
-SERVICES='container1,container2,container3'
+SERVICES='container1 container2 container3'
 
 # Manage docker containers running on a remote machine. To use this feature,
 # you must setup passwordless ssh access between snapRAID host and Docker host.
 # Set to 1 to enable, then enter Docker host SSH user and machine IP or hostname.
 # You can manage multiple remote Docker hosts.
-# Please note: for this configuration DO NOT separate containers with spaces.
-# Use a comma instead.
 # Reference:
-# ('HOSTIP1:container1,container2,container3' 'HOSTIP2:container1,container2,container3,container4')
+# ('HOSTIP1:container1 container2 container3' 'HOSTIP2:container1 container2 container3 container4')
 # Example:
-# ('192.168.0.125:code-server,portainer,plex' '192.168.0.126:nextcloud,handbrake,transmission')
+# ('192.168.0.125:code-server portainer plex' '192.168.0.126:nextcloud handbrake transmission')
 # Delay is the number of seconds to wait before sending the next docker
 # command to avoid errors. Change it if you're experiencing errors.
 DOCKER_REMOTE=0
 DOCKER_USER="sshusernamegoeshere"
-DOCKER_HOST_SERVICES=('HOSTIP1:container1,container2,container3' 'HOSTIP2:container1,container2,container3,container4')
+DOCKER_HOST_SERVICES=('HOSTIP1:container1 container2 container3' 'HOSTIP2:container1 container2 container3 container4')
 DOCKER_DELAY=10
 
 ### CUSTOM HOOKS ###

--- a/script-config.sh
+++ b/script-config.sh
@@ -143,7 +143,7 @@ DOCKER_MODE=1
 # Containers to manage (separated with spaces). Please ensure these containers
 # are always running before executing the script, otherwise an error will be logged.
 DOCKER_LOCAL=0
-SERVICES='container1 container2 container3'
+SERVICES=('container1 container2 container3')
 
 # Manage docker containers running on a remote machine. To use this feature,
 # you must setup passwordless ssh access between snapRAID host and Docker host.

--- a/script-config.sh
+++ b/script-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CONFIG_VERSION=3.3 #-DEV1
+CONFIG_VERSION=3.3 #-DEV2
 ######################
 #   USER VARIABLES   #
 ######################

--- a/script-config.sh
+++ b/script-config.sh
@@ -140,7 +140,7 @@ MANAGE_SERVICES=0
 # This option does not have any effect if MANAGE_SERVICES is set to 0
 DOCKER_MODE=1
 
-# Containers to manage (separated with spaces). Please ensure these containers
+# Containers to manage (separated with spaces, commas, or colons). Please ensure these containers
 # are always running before executing the script, otherwise an error will be logged.
 DOCKER_LOCAL=0
 SERVICES='container1 container2 container3'

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -438,14 +438,12 @@ function sed_me(){
 }
 
 function chk_del(){
-  if [ "$DEL_COUNT" -lt "$DEL_THRESHOLD" ]; then
-    if [ "$DEL_COUNT" -eq 0 ]; then
-      echo "There are no deleted files, that's fine."
-      DO_SYNC=1
-    else
-      echo "There are deleted files. The number of deleted files ($DEL_COUNT) is below the threshold of ($DEL_THRESHOLD)."
-      DO_SYNC=1
-    fi
+  if [ "$DEL_COUNT" -eq 0 ]; then
+    echo "There are no deleted files, that's fine."
+    DO_SYNC=1
+  elif [ "$DEL_COUNT" -lt "$DEL_THRESHOLD" ]; then
+    echo "There are deleted files. The number of deleted files ($DEL_COUNT) is below the threshold of ($DEL_THRESHOLD)."
+    DO_SYNC=1
   elif awk "BEGIN {exit !($ADD_DEL_THRESHOLD > 0)}"; then
     ADD_DEL_RATIO="$(awk -v a=$ADD_COUNT -v b=$DEL_COUNT 'BEGIN {print ( a / b )}')"
     if awk "BEGIN {exit !($ADD_DEL_RATIO >= $ADD_DEL_THRESHOLD)}"; then

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -8,7 +8,7 @@
 ########################
 #   CONFIG VARIABLES   #
 ########################
-SNAPSCRIPTVERSION=3.3 #-DEV2
+SNAPSCRIPTVERSION=3.3 #-DEV3
 
 # Read SnapRAID version
 SNAPRAIDVERSION="$(snapraid -V | sed -e 's/snapraid v\(.*\)by.*/\1/')"

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -51,37 +51,37 @@ function main(){
 
   # Initialize notification
   if [ "$HEALTHCHECKS" -eq 1 ] || [ "$TELEGRAM" -eq 1 ] || [ "$DISCORD" -eq 1 ]; then
-   # install curl if not found
-   if [ "$(dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
-    echo "**Curl has not been found and will be installed.**"
-    mklog "WARN: Curl has not been found and will be installed."
-    # super silent and secret install command
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get install -qq -o=Dpkg::Use-Pty=0 curl;
-   fi
-   # invoke notification services if configured
+    # install curl if not found
+    if [ "$(dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
+      echo "**Curl has not been found and will be installed.**"
+      mklog "WARN: Curl has not been found and will be installed."
+      # super silent and secret install command
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get install -qq -o=Dpkg::Use-Pty=0 curl;
+    fi
+    # invoke notification services if configured
     if [ "$HEALTHCHECKS" -eq 1 ]; then
-   echo "Healthchecks.io notification is enabled. Notifications sent to $HEALTHCHECKS_URL."
-   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/start
-   fi
+      echo "Healthchecks.io notification is enabled. Notifications sent to $HEALTHCHECKS_URL."
+      curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/start
+    fi
     if [ "$TELEGRAM" -eq 1 ]; then
-   echo "Telegram notification is enabled."
-   curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
-     -H 'Content-Type: application/json' \
-     -d '{"chat_id": "'$TELEGRAM_CHAT_ID'", "text": "SnapRAID Script Job started"}' \
-     https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
-     fi
-   if [ "$DISCORD" -eq 1 ]; then
-     echo "Discord notification is enabled."
-     curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
-     -H 'Content-Type: application/json' \
-     -d '{"content": "SnapRAID Script Job started"}' \
-     "$DISCORD_WEBHOOK_URL"
+      echo "Telegram notification is enabled."
+      curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
+      -H 'Content-Type: application/json' \
+      -d '{"chat_id": "'$TELEGRAM_CHAT_ID'", "text": "SnapRAID Script Job started"}' \
+      https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
+    fi
+    if [ "$DISCORD" -eq 1 ]; then
+      echo "Discord notification is enabled."
+      curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
+      -H 'Content-Type: application/json' \
+      -d '{"content": "SnapRAID Script Job started"}' \
+      "$DISCORD_WEBHOOK_URL"
     fi
   fi
 
   if [ "$RETENTION_DAYS" -gt 0 ]; then
-  echo "SnapRAID output retention is enabled. Detailed logs will be kept in $SNAPRAID_LOG_DIR for $RETENTION_DAYS days."
+    echo "SnapRAID output retention is enabled. Detailed logs will be kept in $SNAPRAID_LOG_DIR for $RETENTION_DAYS days."
   fi
 
   # Check if script configuration file has been found, if not send a message
@@ -121,15 +121,11 @@ function main(){
 
   # pause configured containers
   if [ "$MANAGE_SERVICES" -eq 1 ]; then
-   service_array_setup
+    service_array_setup
     if [ "$DOCKERALLOK" = YES ]; then
-     echo
-      if [ "$DOCKER_MODE" = 1 ]; then
-       echo "### Pausing Containers [$(date)]";
-       else
-       echo "### Stopping Containers [$(date)]";
-      fi
-     pause_services
+      echo
+      pause_services
+      echo
     fi
   fi
 
@@ -183,11 +179,9 @@ function main(){
   # CHK 1 - if files have changed
   if [ "$DEL_COUNT" -gt 0 ] || [ "$ADD_COUNT" -gt 0 ] || [ "$MOVE_COUNT" -gt 0 ] || [ "$COPY_COUNT" -gt 0 ] || [ "$UPDATE_COUNT" -gt 0 ]; then
     chk_del
-
     if [ "$CHK_FAIL" -eq 0 ]; then
       chk_updated
     fi
-
     if [ "$CHK_FAIL" -eq 1 ]; then
       chk_sync_warn
     fi
@@ -314,21 +308,17 @@ function main(){
    for DRIVE in $(lsblk -d -o name | tail -n +2)
      do
        if [[ $(smartctl -a /dev/"$DRIVE" | grep 'Rotation Rate' | grep rpm) ]]; then
-         echo "spinning down /dev/$DRIVE"
-         hd-idle -t /dev/"$DRIVE"
+          echo "spinning down /dev/$DRIVE"
+          hd-idle -t /dev/"$DRIVE"
        fi
      done
    fi
 
-  # Resume paused containers
+  # Resume Docker containers
   if [ "$SERVICES_STOPPED" -eq 1 ]; then
     echo
-      if [ "$DOCKER_MODE" = 1 ]; then
-        echo "### Resuming Containers [$(date)]";
-    else
-    echo "### Restarting Containers [$(date)]";
-      fi
     resume_services
+    echo
   fi
 
   # Custom Hook - After
@@ -341,24 +331,24 @@ function main(){
   mklog "INFO: Snapraid: all jobs ended."
 
   # all jobs done
-    # check snapraid output and build the message output
-    # if notification services are enabled, messages will be sent now
-    prepare_output
-    ELAPSED="$((SECONDS / 3600))hrs $(((SECONDS / 60) % 60))min $((SECONDS % 60))sec"
-    echo "----------------------------------------"
-    echo "## Total time elapsed for SnapRAID: $ELAPSED"
-    mklog "INFO: Total time elapsed for SnapRAID: $ELAPSED"
-    # if email or hook service are enabled, will be sent now
-    if [ "$EMAIL_ADDRESS" ] || [ -x "$HOOK_NOTIFICATION" ]; then
-      # Add a topline to email body and send a long mail
-      sed_me "1s:^:##$SUBJECT \n:" "${TMP_OUTPUT}"
-      if [ "$VERBOSITY" -eq 1 ]; then
-        send_mail < "$TMP_OUTPUT"
-      else
+  # check snapraid output and build the message output
+  # if notification services are enabled, messages will be sent now
+  prepare_output
+  ELAPSED="$((SECONDS / 3600))hrs $(((SECONDS / 60) % 60))min $((SECONDS % 60))sec"
+  echo "----------------------------------------"
+  echo "## Total time elapsed for SnapRAID: $ELAPSED"
+  mklog "INFO: Total time elapsed for SnapRAID: $ELAPSED"
+  # if email or hook service are enabled, will be sent now
+  if [ "$EMAIL_ADDRESS" ] || [ -x "$HOOK_NOTIFICATION" ]; then
+    # Add a topline to email body and send a long mail
+    sed_me "1s:^:##$SUBJECT \n:" "${TMP_OUTPUT}"
+    if [ "$VERBOSITY" -eq 1 ]; then
+      send_mail < "$TMP_OUTPUT"
+    else
       # or send a short mail
       trim_log < "$TMP_OUTPUT" | send_mail
-      fi
     fi
+  fi
 
   # Save and rotate logs if enabled
   if [ "$RETENTION_DAYS" -gt 0 ]; then
@@ -414,7 +404,7 @@ function sanity_check() {
         trim_log < "$TMP_OUTPUT" | send_mail
       fi
     exit 1;
-   fi
+    fi
   done
   echo "All content files found."
   mklog "INFO: All content files found."
@@ -461,14 +451,14 @@ function chk_del(){
     fi
   else
     if [ "$RETENTION_DAYS" -gt 0 ]; then
-     echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
-     echo "For more information, please check the DIFF ouput saved in $SNAPRAID_LOG_DIR."
-     mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
-     CHK_FAIL=1
+      echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
+      echo "For more information, please check the DIFF ouput saved in $SNAPRAID_LOG_DIR."
+      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
+      CHK_FAIL=1
     else
-     echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
-     mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
-     CHK_FAIL=1
+      echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
+      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
+      CHK_FAIL=1
     fi
   fi
 }
@@ -484,14 +474,14 @@ function chk_updated(){
     fi
   else
     if [ "$RETENTION_DAYS" -gt 0 ]; then
-     echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
-     echo "For more information, please check the DIFF ouput saved in $SNAPRAID_LOG_DIR."
-     mklog "WARN: Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
-     CHK_FAIL=1
+      echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
+      echo "For more information, please check the DIFF ouput saved in $SNAPRAID_LOG_DIR."
+      mklog "WARN: Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
+      CHK_FAIL=1
     else
-     echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
-     mklog "WARN: Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
-     CHK_FAIL=1
+      echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
+      mklog "WARN: Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
+      CHK_FAIL=1
     fi
   fi
 }
@@ -571,19 +561,19 @@ function chk_zero(){
 }
 
 function chk_scrub_settings(){
-    if [ "$SCRUB_DELAYED_RUN" -gt 0 ]; then
+  if [ "$SCRUB_DELAYED_RUN" -gt 0 ]; then
     echo "Delayed scrub is enabled."
     mklog "INFO: Delayed scrub is enabled.."
   fi
 
-    local scrub_count
+  local scrub_count
   scrub_count=$(sed '/^[0-9]*$/!d' "$SCRUB_COUNT_FILE" 2>/dev/null)
   # zero if file does not exist or did not contain a number
   : "${scrub_count:=0}"
 
-    if [ "$scrub_count" -ge "$SCRUB_DELAYED_RUN" ]; then
-    # Run a scrub job. if the warn count is zero it means the scrub was already
-    # forced, do not output a dumb message and continue with the scrub job.
+  if [ "$scrub_count" -ge "$SCRUB_DELAYED_RUN" ]; then
+  # Run a scrub job. if the warn count is zero it means the scrub was already
+  # forced, do not output a dumb message and continue with the scrub job.
     if [ "$scrub_count" -eq 0 ]; then
       echo
       run_scrub
@@ -607,7 +597,7 @@ function chk_scrub_settings(){
       echo "$((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
       mklog "INFO: $((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
     fi
-    fi
+  fi
 }
 
 function run_scrub(){
@@ -644,98 +634,90 @@ function run_scrub(){
 function service_array_setup() {
   # check if container names are set correctly
   if [ -z "$SERVICES" ] && [ -z "$DOCKER_HOST_SERVICES" ]; then
-   echo "Please configure Containers. Unable to manage containers."
-   ARRAY_VALIDATED=NO
+    echo "Please configure Containers. Unable to manage containers."
+    ARRAY_VALIDATED=NO
   else
-   echo "Docker containers management is enabled."
-   ARRAY_VALIDATED=YES
+    echo "Docker containers management is enabled."
+    ARRAY_VALIDATED=YES
   fi
 
   # check what docker mode is set
   if [ "$DOCKER_MODE" = 1 ]; then
-   DOCKER_CMD1=pause
-   DOCKER_CMD2=unpause
-   DOCKERCMD_VALIDATED=YES
+    DOCKER_CMD1=pause
+    DOCKER_CMD1_LOG="Pausing"
+    DOCKER_CMD2=unpause
+    DOCKER_CMD2_LOG="Unpausing"
+    DOCKERCMD_VALIDATED=YES
   elif [ "$DOCKER_MODE" = 2 ]; then
-   DOCKER_CMD1=stop
-   DOCKER_CMD2=start
-   DOCKERCMD_VALIDATED=YES
+    DOCKER_CMD1=stop
+    DOCKER_CMD1_LOG="Stopping"
+    DOCKER_CMD2=start
+    DOCKER_CMD2_LOG="Starting"
+    DOCKERCMD_VALIDATED=YES
   else
-   echo "Please check your command configuration. Unable to manage containers."
-   DOCKERCMD_VALIDATED=NO
+    echo "Please check your command configuration. Unable to manage containers."
+    DOCKERCMD_VALIDATED=NO
   fi
 
   # validate docker configuration
   if [ "$ARRAY_VALIDATED" = YES ] && [ "$DOCKERCMD_VALIDATED" = YES ]; then
-   DOCKERALLOK=YES
+    DOCKERALLOK=YES
   else
-   DOCKERALLOK=NO
+    DOCKERALLOK=NO
   fi
 }
 
 function pause_services(){
+  echo "### $DOCKER_CMD1_LOG Containers [$(date)]";
   if [ "$DOCKER_LOCAL" -eq 1 ]; then
-    if [ "$DOCKER_MODE" = 1 ]; then
-      echo "Pausing Local Container(s)";
-    else
-      echo "Stopping Local Container(s)";
-    fi
+    echo "$DOCKER_CMD1_LOG Local Container(s)";
     docker $DOCKER_CMD1 $SERVICES
   fi
   if [ "$DOCKER_REMOTE" -eq 1 ]; then
+    IFS=':, '
     for (( i=0; i < "${#DOCKER_HOST_SERVICES[@]}"; i++ )); do
       # delete previous array/list (this is crucial!)
       unset tmpArray
-      IFS=':, ' read -r -a tmpArray <<< "${DOCKER_HOST_SERVICES[i]}"
+      read -r -a tmpArray <<< "${DOCKER_HOST_SERVICES[i]}"
       REMOTE_HOST="${tmpArray[0]}"
       REMOTE_SERVICES=""
       for (( j=1; j < "${#tmpArray[@]}"; j++ )); do
         REMOTE_SERVICES="$REMOTE_SERVICES${tmpArray[j]} "
       done
-      if [ "$DOCKER_MODE" = 1 ]; then
-        echo "Pausing Container(s) on $REMOTE_HOST";
-      else
-        echo "Stopping Container(s) on $REMOTE_HOST";
-      fi
+      echo "$DOCKER_CMD1_LOG Container(s) on $REMOTE_HOST";
       ssh "$DOCKER_USER"@"$REMOTE_HOST" docker "$DOCKER_CMD1" "$REMOTE_SERVICES"
       sleep "$DOCKER_DELAY"
     done
+    unset IFS
   fi
   SERVICES_STOPPED=1
-  unset IFS
 }
 
 function resume_services(){
   if [ "$SERVICES_STOPPED" -eq 1 ]; then
+    echo "### $DOCKER_CMD2_LOG Containers [$(date)]";
     if [ "$DOCKER_LOCAL" -eq 1 ]; then
-      if [ "$DOCKER_MODE" = 1 ]; then
-        echo "Resuming Local Container(s)";
-      else
-        echo "Restarting Local Container(s)";
-      fi
+      echo "$DOCKER_CMD2_LOG Local Container(s)";
       docker $DOCKER_CMD2 $SERVICES
     fi
     if [ "$DOCKER_REMOTE" -eq 1 ]; then
+      IFS=':, '
       for (( i=0; i < "${#DOCKER_HOST_SERVICES[@]}"; i++ )); do
         # delete previous array/list (this is crucial!)
         unset tmpArray
-        IFS=':, ' read -r -a tmpArray <<< "${DOCKER_HOST_SERVICES[i]}"
+        read -r -a tmpArray <<< "${DOCKER_HOST_SERVICES[i]}"
         REMOTE_HOST="${tmpArray[0]}"
         REMOTE_SERVICES=""
         for (( j=1; j < "${#tmpArray[@]}"; j++ )); do
           REMOTE_SERVICES="$REMOTE_SERVICES${tmpArray[j]} "
         done
-        if [ "$DOCKER_MODE" = 1 ]; then
-          echo "Resuming Container(s) on $REMOTE_HOST";
-        else
-          echo "Restarting Container(s) on $REMOTE_HOST";
-        fi
+        echo "$DOCKER_CMD2_LOG Container(s) on $REMOTE_HOST";
         ssh "$DOCKER_USER"@"$REMOTE_HOST" docker "$DOCKER_CMD2" "$REMOTE_SERVICES"
         sleep "$DOCKER_DELAY"
       done
+      unset IFS
     fi
     SERVICES_STOPPED=0
-    unset IFS
   fi
 }
 
@@ -815,37 +797,37 @@ SUMMARY: Equal [$EQ_COUNT] - Added [$ADD_COUNT] - Deleted [$DEL_COUNT] - Moved [
 
 function notify_success(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/0 --data-raw "$NOTIFY_OUTPUT"
+    curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/0 --data-raw "$NOTIFY_OUTPUT"
   fi
   if [ "$TELEGRAM" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
-   -H 'Content-Type: application/json' \
-   -d '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$NOTIFY_OUTPUT"'"}' \
-   https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
+    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$NOTIFY_OUTPUT"'"}' \
+    https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
   fi
   if [ "$DISCORD" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
-   -H 'Content-Type: application/json' \
-   -d '{"content": "'"$SUBJECT"'"}' \
-   "$DISCORD_WEBHOOK_URL"
+    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"content": "'"$SUBJECT"'"}' \
+    "$DISCORD_WEBHOOK_URL"
   fi
   }
 
 function notify_warning(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/fail --data-raw "$NOTIFY_OUTPUT"
+    curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/fail --data-raw "$NOTIFY_OUTPUT"
   fi
   if [ "$TELEGRAM" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
-   -H 'Content-Type: application/json' \
-   -d '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$NOTIFY_OUTPUT"'"}' \
-   https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
+    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"chat_id": "'"$TELEGRAM_CHAT_ID"'", "text": "'"$NOTIFY_OUTPUT"'"}' \
+    https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
   fi
   if [ "$DISCORD" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
-   -H 'Content-Type: application/json' \
-   -d '{"content": "'"$SUBJECT"'"}' \
-   "$DISCORD_WEBHOOK_URL"
+    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"content": "'"$SUBJECT"'"}' \
+    "$DISCORD_WEBHOOK_URL"
   fi
   }
 

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 ########################################################################
-#                                      #
+#                                                                      #
 #   Project page: https://github.com/auanasgheps/snapraid-aio-script   #
-#                                      #
+#                                                                      #
 ########################################################################
 
-######################
-#   CONFIG VARIABLES #
-######################
-SNAPSCRIPTVERSION="3.3DEV2"
+########################
+#   CONFIG VARIABLES   #
+########################
+SNAPSCRIPTVERSION=3.3 #-DEV2
 
 # Read SnapRAID version
 SNAPRAIDVERSION="$(snapraid -V | sed -e 's/snapraid v\(.*\)by.*/\1/')"
@@ -205,13 +205,13 @@ function main(){
     mklog "INFO: SnapRAID SYNC Job started"
     echo "\`\`\`"
     if [ "$PREHASH" -eq 1 ] && [ "$FORCE_ZERO" -eq 1 ]; then
-      $SNAPRAID_BIN sync -h --force-zero -q
+      $SNAPRAID_BIN -h --force-zero -q sync
     elif [ "$PREHASH" -eq 1 ]; then
-      $SNAPRAID_BIN sync -h -q
+      $SNAPRAID_BIN -h -q sync
     elif [ "$FORCE_ZERO" -eq 1 ]; then
-      $SNAPRAID_BIN sync --force-zero -q
+      $SNAPRAID_BIN --force-zero -q sync
     else
-      $SNAPRAID_BIN sync -q
+      $SNAPRAID_BIN -q sync
     fi
     close_output_and_wait
     output_to_file_screen
@@ -614,7 +614,7 @@ function run_scrub(){
   if [ "$SCRUB_NEW" -eq 1 ]; then
   echo "SCRUB New Blocks [$(date)]"
     echo "\`\`\`"
-    $SNAPRAID_BIN scrub -p new -q
+    $SNAPRAID_BIN -p new -q scrub
     close_output_and_wait
     output_to_file_screen
     echo "\`\`\`"

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -685,9 +685,9 @@ function pause_services(){
         REMOTE_SERVICES="$REMOTE_SERVICES${tmpArray[j]} "
       done
       if [ "$DOCKER_MODE" = 1 ]; then
-        echo "Pausing Container(s) on $REMOTE_HOST - $REMOTE_SERVICES";
+        echo "Pausing Container(s) on $REMOTE_HOST";
       else
-        echo "Stopping Container(s) on $REMOTE_HOST - $REMOTE_SERVICES";
+        echo "Stopping Container(s) on $REMOTE_HOST";
       fi
       ssh "$DOCKER_USER"@"$REMOTE_HOST" docker "$DOCKER_CMD1" "$REMOTE_SERVICES"
       sleep "$DOCKER_DELAY"
@@ -695,9 +695,9 @@ function pause_services(){
   fi
   if [ "$DOCKER_LOCAL" -eq 1 ]; then
     if [ "$DOCKER_MODE" = 1 ]; then
-      echo "Pausing Local Container(s) - $SERVICES";
+      echo "Pausing Local Container(s)";
     else
-      echo "Stopping Local Container(s) - $SERVICES";
+      echo "Stopping Local Container(s)";
     fi
     docker $DOCKER_CMD1 $SERVICES
   fi
@@ -718,9 +718,9 @@ function resume_services(){
           REMOTE_SERVICES="$REMOTE_SERVICES${tmpArray[j]} "
         done
         if [ "$DOCKER_MODE" = 1 ]; then
-          echo "Resuming Container(s) on ""$REMOTE_HOST"" - ""$REMOTE_SERVICES";
+          echo "Resuming Container(s) on $REMOTE_HOST";
         else
-          echo "Restarting Container(s) on ""$REMOTE_HOST"" - ""$REMOTE_SERVICES";
+          echo "Restarting Container(s) on $REMOTE_HOST";
         fi
         ssh "$DOCKER_USER"@"$REMOTE_HOST" docker "$DOCKER_CMD2" "$REMOTE_SERVICES"
         sleep "$DOCKER_DELAY"
@@ -728,9 +728,9 @@ function resume_services(){
     fi
     if [ "$DOCKER_LOCAL" -eq 1 ]; then
       if [ "$DOCKER_MODE" = 1 ]; then
-        echo "Resuming Local Container(s) - ""$SERVICES";
+        echo "Resuming Local Container(s)";
       else
-        echo "Restarting Local Container(s) - ""$SERVICES";
+        echo "Restarting Local Container(s)";
       fi
       docker $DOCKER_CMD2 $SERVICES
     fi

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 ########################################################################
-#								       #
+#                                                                      #
 #   Project page: https://github.com/auanasgheps/snapraid-aio-script   #
-#								       #
+#                                                                      #
 ########################################################################
 
-######################
-#   CONFIG VARIABLES #
-######################
-SNAPSCRIPTVERSION=3.2 #-DEV5
+########################
+#   CONFIG VARIABLES   #
+########################
+SNAPSCRIPTVERSION=3.3 #-DEV1
 
 # Read SnapRAID version
 SNAPRAIDVERSION="$(snapraid -V | sed -e 's/snapraid v\(.*\)by.*/\1/')"
@@ -25,14 +25,14 @@ source "$CONFIG_FILE"
 SYNC_MARKER="SYNC -"
 SCRUB_MARKER="SCRUB -"
 
-######################
-#   MAIN SCRIPT      #
-######################
+####################
+#   MAIN SCRIPT    #
+####################
 
 function main(){
   # create tmp file for output
   true > "$TMP_OUTPUT"
-    
+
   # Redirect all output to file and screen. Starts a tee process
   output_to_file_screen
 
@@ -49,7 +49,7 @@ function main(){
 
   echo "## Preprocessing"
 
-  # Initialize notification 
+  # Initialize notification
   if [ "$HEALTHCHECKS" -eq 1 ] || [ "$TELEGRAM" -eq 1 ] || [ "$DISCORD" -eq 1 ]; then
    # install curl if not found
    if [ "$(dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
@@ -61,8 +61,8 @@ function main(){
    fi
    # invoke notification services if configured
     if [ "$HEALTHCHECKS" -eq 1 ]; then
-   echo "Healthchecks.io notification is enabled."
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/start
+   echo "Healthchecks.io notification is enabled. Notifications sent to $HEALTHCHECKS_URL."
+   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/start
    fi
     if [ "$TELEGRAM" -eq 1 ]; then
    echo "Telegram notification is enabled."
@@ -70,7 +70,7 @@ function main(){
      -H 'Content-Type: application/json' \
      -d '{"chat_id": "'$TELEGRAM_CHAT_ID'", "text": "SnapRAID Script Job started"}' \
      https://api.telegram.org/bot"$TELEGRAM_TOKEN"/sendMessage
-	 fi
+     fi
    if [ "$DISCORD" -eq 1 ]; then
      echo "Discord notification is enabled."
      curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
@@ -80,7 +80,7 @@ function main(){
     fi
   fi
 
-  if [ "$RETENTION_DAYS" -gt 0 ]; then 
+  if [ "$RETENTION_DAYS" -gt 0 ]; then
   echo "SnapRAID output retention is enabled. Detailed logs will be kept in $SNAPRAID_LOG_DIR for $RETENTION_DAYS days."
   fi
 
@@ -88,8 +88,8 @@ function main(){
   # to syslog and exit
   if [ ! -f "$CONFIG_FILE" ]; then
     echo "Script configuration file not found! The script cannot be run! Please check and try again!"
-	mklog_noconfig "WARN: Script configuration file not found! The script cannot be run! Please check and try again!"
-	exit 1;
+    mklog_noconfig "WARN: Script configuration file not found! The script cannot be run! Please check and try again!"
+    exit 1;
   # check if the config file has the correct version
   elif [ "$CONFIG_VERSION" != "$SNAPSCRIPTVERSION" ]; then
     echo "Please update your config file to the latest version. The current file is not compatible with this script!"
@@ -100,7 +100,7 @@ function main(){
       trim_log < "$TMP_OUTPUT" | send_mail
       notify_warning
     fi
-	exit 1;
+    exit 1;
   else
     echo "Configuration file found."
     mklog "INFO: Script configuration file found."
@@ -166,13 +166,13 @@ function main(){
     # failed to get one or more of the count values, lets report to user and
     # exit with error code
     echo "**ERROR** - Failed to get one or more count values. Unable to continue."
-	mklog "WARN: Failed to get one or more count values. Unable to continue."
+    mklog "WARN: Failed to get one or more count values. Unable to continue."
     echo "Exiting script. [$(date)]"
     if [ "$EMAIL_ADDRESS" ]; then
       SUBJECT="[WARNING] - Unable to continue with SYNC/SCRUB job(s). Check DIFF job output. $EMAIL_SUBJECT_PREFIX"
-	    NOTIFY_OUTPUT="$SUBJECT"
+        NOTIFY_OUTPUT="$SUBJECT"
       trim_log < "$TMP_OUTPUT" | send_mail
-	  notify_warning
+      notify_warning
     fi
     exit 1;
   fi
@@ -205,13 +205,13 @@ function main(){
     mklog "INFO: SnapRAID SYNC Job started"
     echo "\`\`\`"
     if [ "$PREHASH" -eq 1 ] && [ "$FORCE_ZERO" -eq 1 ]; then
-	  $SNAPRAID_BIN sync -h --force-zero -q
-	elif [ "$PREHASH" -eq 1 ]; then 
-      $SNAPRAID_BIN sync -h -q 
-    elif [ "$FORCE_ZERO" -eq 1 ]; then  
-	  $SNAPRAID_BIN sync --force-zero -q
-	else
-      $SNAPRAID_BIN sync -q 
+      $SNAPRAID_BIN -h --force-zero -q sync
+    elif [ "$PREHASH" -eq 1 ]; then
+      $SNAPRAID_BIN -h -q sync
+    elif [ "$FORCE_ZERO" -eq 1 ]; then
+      $SNAPRAID_BIN --force-zero -q sync
+    else
+      $SNAPRAID_BIN -q sync
     fi
     close_output_and_wait
     output_to_file_screen
@@ -234,14 +234,14 @@ function main(){
 
   # Moving onto scrub now. Check if user has enabled scrub
   echo "### SnapRAID SCRUB [$(date)]"
-	mklog "INFO: SnapRAID SCRUB Job started"
+    mklog "INFO: SnapRAID SCRUB Job started"
   if [ "$SCRUB_PERCENT" -gt 0 ]; then
     # YES, first let's check if delete threshold has been breached and we have
     # not forced a sync.
     if [ "$CHK_FAIL" -eq 1 ] && [ "$DO_SYNC" -eq 0 ]; then
       # YES, parity is out of sync so let's not run scrub job
       echo "Parity info is out of sync (deleted or changed files threshold has been breached)."
-	  echo "Not running SCRUB job. [$(date)]"
+      echo "Not running SCRUB job. [$(date)]"
       mklog "INFO: Parity info is out of sync (deleted or changed files threshold has been breached). Not running SCRUB job."
     else
       # NO, delete threshold has not been breached OR we forced a sync, but we
@@ -250,8 +250,8 @@ function main(){
       if [ "$DO_SYNC" -eq 1 ] && ! grep -qw "$SYNC_MARKER" "$TMP_OUTPUT"; then
         # Sync ran but did not complete successfully so lets not run scrub to
         # be safe
-        echo "**WARNING** - check output of SYNC job. Could not detect marker."
-		echo "Not running SCRUB job. [$(date)]"
+        echo "**WARNING!** - Check output of SYNC job. Could not detect marker."
+        echo "Not running SCRUB job. [$(date)]"
         mklog "WARN: Check output of SYNC job. Could not detect marker. Not running SCRUB job."
       else
         # Everything ok - ready to run the scrub job!
@@ -262,7 +262,7 @@ function main(){
     fi
   else
     echo "Scrub job is not enabled. "
-	echo "Not running SCRUB job. [$(date)]"
+    echo "Not running SCRUB job. [$(date)]"
     mklog "INFO: Scrub job is not enabled. Not running SCRUB job."
   fi
 
@@ -325,8 +325,8 @@ function main(){
     echo
       if [ "$DOCKER_MODE" = 1 ]; then
         echo "### Resuming Containers [$(date)]";
-	else
-	echo "### Restarting Containers [$(date)]";
+    else
+    echo "### Restarting Containers [$(date)]";
       fi
     resume_services
   fi
@@ -355,15 +355,15 @@ function main(){
     if [ "$VERBOSITY" -eq 1 ]; then
       send_mail < "$TMP_OUTPUT"
     else
-	# or send a short mail
+    # or send a short mail
      trim_log < "$TMP_OUTPUT" | send_mail
     fi
   fi
 
-  # Save and rotate logs if enabled 
-  if [ "$RETENTION_DAYS" -gt 0 ]; then 
+  # Save and rotate logs if enabled
+  if [ "$RETENTION_DAYS" -gt 0 ]; then
     find "$SNAPRAID_LOG_DIR"/SnapRAID-* -mtime +"$RETENTION_DAYS" -delete  # delete old logs
-    cp $TMP_OUTPUT "$SNAPRAID_LOG_DIR"/SnapRAID-"$(date +"%Y_%m_%d-%H%M")".out 
+    cp $TMP_OUTPUT "$SNAPRAID_LOG_DIR"/SnapRAID-"$(date +"%Y_%m_%d-%H%M")".out
   fi
 
   # exit with success, letting the trap handle cleanup of file descriptors
@@ -379,8 +379,8 @@ function sanity_check() {
   mklog "INFO: Checking if all parity and content files are present."
   for i in "${PARITY_FILES[@]}"; do
     if [ ! -e "$i" ]; then
-	echo "[$(date)] ERROR - Parity file ($i) not found!"
-	echo "ERROR - Parity file ($i) not found!" >> "$TMP_OUTPUT"
+    echo "[$(date)] ERROR - Parity file ($i) not found!"
+    echo "ERROR - Parity file ($i) not found!" >> "$TMP_OUTPUT"
     echo "**ERROR**: Please check the status of your disks! The script exits here due to missing file or disk."
     mklog "WARN: Parity file ($i) not found!"
     mklog "WARN: Please check the status of your disks! The script exits here due to missing file or disk."
@@ -389,7 +389,7 @@ function sanity_check() {
     SUBJECT="[WARNING] - Parity file ($i) not found! $EMAIL_SUBJECT_PREFIX"
     NOTIFY_OUTPUT="$SUBJECT"
     trim_log < "$TMP_OUTPUT" | send_mail
-	notify_warning
+    notify_warning
     exit 1;
   fi
   done
@@ -408,7 +408,7 @@ function sanity_check() {
       SUBJECT="[WARNING] - Content file ($i) not found! $EMAIL_SUBJECT_PREFIX"
       NOTIFY_OUTPUT="$SUBJECT"
       trim_log < "$TMP_OUTPUT" | send_mail
-	  notify_warning
+      notify_warning
     exit 1;
    fi
   done
@@ -450,19 +450,19 @@ function chk_del(){
       echo "There are deleted files. The number of deleted files ($DEL_COUNT) is above the threshold of ($DEL_THRESHOLD)"
       echo "but the add/delete ratio of ($ADD_DEL_RATIO) is above the threshold of ($ADD_DEL_THRESHOLD), sync will proceed."
       DO_SYNC=1
-    else 
-      echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete threshold ($ADD_DEL_THRESHOLD) was not met."
+    else
+      echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete threshold ($ADD_DEL_THRESHOLD) was not met."
       mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD) and add/delete threshold ($ADD_DEL_THRESHOLD) was not met."
       CHK_FAIL=1
     fi
   else
-    if [ "$RETENTION_DAYS" -gt 0 ]; then 
-     echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
+    if [ "$RETENTION_DAYS" -gt 0 ]; then
+     echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
      echo "For more information, please check the DIFF ouput saved in $SNAPRAID_LOG_DIR."
      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
      CHK_FAIL=1
     else
-     echo "**WARNING** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
+     echo "**WARNING!** Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
      mklog "WARN: Deleted files ($DEL_COUNT) reached/exceeded threshold ($DEL_THRESHOLD)."
      CHK_FAIL=1
     fi
@@ -479,13 +479,13 @@ function chk_updated(){
       DO_SYNC=1
     fi
   else
-    if [ "$RETENTION_DAYS" -gt 0 ]; then 
-     echo "**WARNING** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
+    if [ "$RETENTION_DAYS" -gt 0 ]; then
+     echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
      echo "For more information, please check the DIFF ouput saved in $SNAPRAID_LOG_DIR."
      mklog "WARN: Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
      CHK_FAIL=1
     else
-     echo "**WARNING** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
+     echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
      mklog "WARN: Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."
      CHK_FAIL=1
     fi
@@ -536,10 +536,10 @@ function chk_sync_warn(){
     fi
   else
     # NO, so let's skip SYNC
-    if [ "$RETENTION_DAYS" -gt 0 ]; then 
+    if [ "$RETENTION_DAYS" -gt 0 ]; then
     echo "Forced sync is not enabled. **NOT** proceeding with SYNC job. [$(date)]"
     mklog "INFO: Forced sync is not enabled. **NOT** proceeding with SYNC job."
-    DO_SYNC=0    
+    DO_SYNC=0
     else
     echo "Forced sync is not enabled. Check $TMP_OUTPUT for details. **NOT** proceeding with SYNC job. [$(date)]"
     mklog "INFO: Forced sync is not enabled. Check $TMP_OUTPUT for details. **NOT** proceeding with SYNC job."
@@ -567,17 +567,17 @@ function chk_zero(){
 }
 
 function chk_scrub_settings(){
-	if [ "$SCRUB_DELAYED_RUN" -gt 0 ]; then
+    if [ "$SCRUB_DELAYED_RUN" -gt 0 ]; then
     echo "Delayed scrub is enabled."
     mklog "INFO: Delayed scrub is enabled.."
   fi
 
-	local scrub_count
+    local scrub_count
   scrub_count=$(sed '/^[0-9]*$/!d' "$SCRUB_COUNT_FILE" 2>/dev/null)
   # zero if file does not exist or did not contain a number
   : "${scrub_count:=0}"
 
-	if [ "$scrub_count" -ge "$SCRUB_DELAYED_RUN" ]; then
+    if [ "$scrub_count" -ge "$SCRUB_DELAYED_RUN" ]; then
     # Run a scrub job. if the warn count is zero it means the scrub was already
     # forced, do not output a dumb message and continue with the scrub job.
     if [ "$scrub_count" -eq 0 ]; then
@@ -592,7 +592,7 @@ function chk_scrub_settings(){
       echo
       run_scrub
     fi
-	else
+    else
     # NO, so let's increment the warning count and skip the scrub job
     ((scrub_count += 1))
     echo "$scrub_count" > "$SCRUB_COUNT_FILE"
@@ -603,21 +603,21 @@ function chk_scrub_settings(){
       echo "$((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
       mklog "INFO: $((SCRUB_DELAYED_RUN - scrub_count)) runs until the next scrub. **NOT** proceeding with SCRUB job. [$(date)]"
     fi
-	fi
+    fi
 }
 
 function run_scrub(){
   if [ "$SCRUB_NEW" -eq 1 ]; then
   echo "SCRUB New Blocks [$(date)]"
-	echo "\`\`\`"
-    $SNAPRAID_BIN scrub -p new -q
+    echo "\`\`\`"
+    $SNAPRAID_BIN -p new -q scrub
     close_output_and_wait
     output_to_file_screen
-	echo "\`\`\`"
+    echo "\`\`\`"
   fi
-  echo "SCRUB Old Blocks [$(date)]"
+  echo "SCRUB Previous Blocks [$(date)]"
   echo "\`\`\`"
-  $SNAPRAID_BIN scrub -p "$SCRUB_PERCENT" -o "$SCRUB_AGE" -q
+  $SNAPRAID_BIN -p "$SCRUB_PERCENT" -o "$SCRUB_AGE" -q scrub
   close_output_and_wait
   output_to_file_screen
   echo "\`\`\`"
@@ -695,8 +695,8 @@ function pause_services(){
      sleep "$DOCKER_DELAY"
     done
    done
-  else
-   IFS=' ' read -r -a service_array <<<"$SERVICES"
+  if [ "$DOCKER_LOCAL" -eq 1 ]; then
+   IFS=',' read -r -a service_array <<<"$SERVICES"
    for i in "${service_array[@]}"; do
     if [ "$DOCKER_MODE" = 1 ]; then
      echo "Pausing Container - ""${i^}";
@@ -737,8 +737,8 @@ function resume_services(){
       sleep "$DOCKER_DELAY"
      done
     done
-   else
-    IFS=' ' read -r -a service_array <<<"$SERVICES"
+   if [ "$DOCKER_LOCAL" -eq 1 ]; then
+    IFS=',' read -r -a service_array <<<"$SERVICES"
     for i in "${service_array[@]}"; do
      if [ "$DOCKER_MODE" = 1 ]; then
       echo "Resuming Container - ""${i^}";
@@ -767,14 +767,14 @@ function prepare_mail() {
   if [ $CHK_FAIL -eq 1 ]; then
     if [ "$DEL_COUNT" -ge "$DEL_THRESHOLD" ] && [ "$DO_SYNC" -eq 0 ]; then
       MSG="Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) violation"
-	  if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
+      if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
         MSG="Multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) and add/delete ratio ($ADD_DEL_RATIO) / ($ADD_DEL_THRESHOLD)"
       fi
     fi
 
     if [ "$DEL_COUNT" -ge "$DEL_THRESHOLD" ] && [ "$DO_SYNC" -eq 1 ]; then
       MSG="Forced sync with deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) violation"
-	  if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
+      if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
         MSG="Sync forced with multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) and add/delete ratio ($ADD_DEL_RATIO) / ($ADD_DEL_THRESHOLD)"
       fi
     fi
@@ -789,42 +789,42 @@ function prepare_mail() {
 
     if [ "$DEL_COUNT" -ge  "$DEL_THRESHOLD" ] && [ "$UPDATE_COUNT" -ge "$UP_THRESHOLD" ] && [ "$DO_SYNC" -eq 0 ]; then
       MSG="Multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) and changed files ($UPDATE_COUNT) / ($UP_THRESHOLD)"
-	  if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
+      if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
         MSG="Multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD), add/delete ratio ($ADD_DEL_RATIO) / ($ADD_DEL_THRESHOLD), and changed files ($UPDATE_COUNT) / ($UP_THRESHOLD)"
       fi
     fi
 
     if [ "$DEL_COUNT" -ge  "$DEL_THRESHOLD" ] && [ "$UPDATE_COUNT" -ge "$UP_THRESHOLD" ] && [ "$DO_SYNC" -eq 1 ]; then
       MSG="Sync forced with multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD) and changed files ($UPDATE_COUNT) / ($UP_THRESHOLD)"
-	  if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
+      if awk "BEGIN {exit !($ADD_DEL_RATIO < $ADD_DEL_THRESHOLD)}"; then
         MSG="Sync forced with multiple violations - Deleted files ($DEL_COUNT) / ($DEL_THRESHOLD), add/delete ratio ($ADD_DEL_RATIO) / ($ADD_DEL_THRESHOLD), and changed files ($UPDATE_COUNT) / ($UP_THRESHOLD)"
       fi
     fi
     SUBJECT="[WARNING] $MSG $EMAIL_SUBJECT_PREFIX"
-	NOTIFY_OUTPUT="$SUBJECT"
-	notify_warning
+    NOTIFY_OUTPUT="$SUBJECT"
+    notify_warning
   elif [ -z "${JOBS_DONE##*"SYNC"*}" ] && ! grep -qw "$SYNC_MARKER" "$TMP_OUTPUT"; then
     # Sync ran but did not complete successfully so lets warn the user
     SUBJECT="[WARNING] SYNC job ran but did not complete successfully $EMAIL_SUBJECT_PREFIX"
-	NOTIFY_OUTPUT="$SUBJECT"
-	notify_warning
+    NOTIFY_OUTPUT="$SUBJECT"
+    notify_warning
   elif [ -z "${JOBS_DONE##*"SCRUB"*}" ] && ! grep -qw "$SCRUB_MARKER" "$TMP_OUTPUT"; then
     # Scrub ran but did not complete successfully so lets warn the user
     SUBJECT="[WARNING] SCRUB job ran but did not complete successfully $EMAIL_SUBJECT_PREFIX"
-	NOTIFY_OUTPUT="$SUBJECT
+    NOTIFY_OUTPUT="$SUBJECT
 SUMMARY: Equal [$EQ_COUNT] - Added [$ADD_COUNT] - Deleted [$DEL_COUNT] - Moved [$MOVE_COUNT] - Copied [$COPY_COUNT] - Updated [$UPDATE_COUNT]"
-	notify_warning
+    notify_warning
   else
     SUBJECT="[COMPLETED] $JOBS_DONE Jobs $EMAIL_SUBJECT_PREFIX"
-	NOTIFY_OUTPUT="$SUBJECT
+    NOTIFY_OUTPUT="$SUBJECT
 SUMMARY: Equal [$EQ_COUNT] - Added [$ADD_COUNT] - Deleted [$DEL_COUNT] - Moved [$MOVE_COUNT] - Copied [$COPY_COUNT] - Updated [$UPDATE_COUNT]"
-	notify_success
+    notify_success
   fi
 }
 
 function notify_success(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/0 --data-raw "$NOTIFY_OUTPUT"
+   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/0 --data-raw "$NOTIFY_OUTPUT"
   fi
   if [ "$TELEGRAM" -eq 1 ]; then
    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \
@@ -842,7 +842,7 @@ function notify_success(){
 
 function notify_warning(){
   if [ "$HEALTHCHECKS" -eq 1 ]; then
-   curl -fsS -m 5 --retry 3 -o /dev/null https://hc-ping.com/"$HEALTHCHECKS_ID"/fail --data-raw "$NOTIFY_OUTPUT"
+   curl -fsS -m 5 --retry 3 -o /dev/null "$HEALTHCHECKS_URL$HEALTHCHECKS_ID"/fail --data-raw "$NOTIFY_OUTPUT"
   fi
   if [ "$TELEGRAM" -eq 1 ]; then
    curl -fsS -m 5 --retry 3 -o /dev/null -X POST \

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -674,6 +674,14 @@ function service_array_setup() {
 }
 
 function pause_services(){
+  if [ "$DOCKER_LOCAL" -eq 1 ]; then
+    if [ "$DOCKER_MODE" = 1 ]; then
+      echo "Pausing Local Container(s)";
+    else
+      echo "Stopping Local Container(s)";
+    fi
+    docker $DOCKER_CMD1 $SERVICES
+  fi
   if [ "$DOCKER_REMOTE" -eq 1 ]; then
     for (( i=0; i < "${#DOCKER_HOST_SERVICES[@]}"; i++ )); do
       # delete previous array/list (this is crucial!)
@@ -693,20 +701,20 @@ function pause_services(){
       sleep "$DOCKER_DELAY"
     done
   fi
-  if [ "$DOCKER_LOCAL" -eq 1 ]; then
-    if [ "$DOCKER_MODE" = 1 ]; then
-      echo "Pausing Local Container(s)";
-    else
-      echo "Stopping Local Container(s)";
-    fi
-    docker $DOCKER_CMD1 $SERVICES
-  fi
   SERVICES_STOPPED=1
   unset IFS
 }
 
 function resume_services(){
   if [ "$SERVICES_STOPPED" -eq 1 ]; then
+    if [ "$DOCKER_LOCAL" -eq 1 ]; then
+      if [ "$DOCKER_MODE" = 1 ]; then
+        echo "Resuming Local Container(s)";
+      else
+        echo "Restarting Local Container(s)";
+      fi
+      docker $DOCKER_CMD2 $SERVICES
+    fi
     if [ "$DOCKER_REMOTE" -eq 1 ]; then
       for (( i=0; i < "${#DOCKER_HOST_SERVICES[@]}"; i++ )); do
         # delete previous array/list (this is crucial!)
@@ -725,14 +733,6 @@ function resume_services(){
         ssh "$DOCKER_USER"@"$REMOTE_HOST" docker "$DOCKER_CMD2" "$REMOTE_SERVICES"
         sleep "$DOCKER_DELAY"
       done
-    fi
-    if [ "$DOCKER_LOCAL" -eq 1 ]; then
-      if [ "$DOCKER_MODE" = 1 ]; then
-        echo "Resuming Local Container(s)";
-      else
-        echo "Restarting Local Container(s)";
-      fi
-      docker $DOCKER_CMD2 $SERVICES
     fi
     SERVICES_STOPPED=0
     unset IFS


### PR DESCRIPTION
Changes to allow management of both local and remote docker containers instead of one or the other.

Modified remote IFS to allow separators of `,` `:` or ` ` and updated documentation of remote services for consistency with local services.

Container management is now done with a single command for all containers, so the delay for remote may no longer be necessary. It remains in the config, but the default value is now `0`.

Reordered the `snapraid` commands after the options to align with the manual. https://www.snapraid.it/manual

Trimmed trailing spaces.