### PR TITLE
bugfix chk_updated function to correctly check if UPDATED_COUNT var is 0

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -484,14 +484,12 @@ function chk_del(){
 }
 
 function chk_updated(){
-  if [ "$UPDATE_COUNT" -lt "$UP_THRESHOLD" ]; then
-    if [ "$UPDATE_COUNT" -eq 0 ]; then
-      echo "There are no updated files, that's fine."
-      DO_SYNC=1
-    else
+  if [ "$UPDATE_COUNT" -eq 0 ]; then
+    echo "There are no updated files, that's fine."
+    DO_SYNC=1
+  elif [ "$UPDATE_COUNT" -lt "$UP_THRESHOLD" ]; then
       echo "There are updated files. The number of updated files ($UPDATE_COUNT) is below the threshold of ($UP_THRESHOLD)."
       DO_SYNC=1
-    fi
   else
     if [ "$RETENTION_DAYS" -gt 0 ]; then
       echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."


### PR DESCRIPTION
Bug: on master, if UPDATE_COUNT is 0 but UP_THRESHOLD is set to 0, the if statement never triggers, leading to the snapraid commands not continuing.  
Bugfix on chk_updated function to allow if statement [ "$UPDATE_COUNT" -eq 0 ] to trigger even if UPDATE_COUNT is not less than UP_THRESHOLD var.  This allows the script to continue if there are 0 updates, even if UP_THRESHOLD is set to 0.
This is the same logic already in chk_del lines 454-456. :)
