### PR TITLE
bugfix chk_updated function

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -484,14 +484,12 @@ function chk_del(){
 }
 
 function chk_updated(){
-  if [ "$UPDATE_COUNT" -lt "$UP_THRESHOLD" ]; then
-    if [ "$UPDATE_COUNT" -eq 0 ]; then
-      echo "There are no updated files, that's fine."
-      DO_SYNC=1
-    else
+  if [ "$UPDATE_COUNT" -eq 0 ]; then
+    echo "There are no updated files, that's fine."
+    DO_SYNC=1
+  elif [ "$UPDATE_COUNT" -lt "$UP_THRESHOLD" ]; then
       echo "There are updated files. The number of updated files ($UPDATE_COUNT) is below the threshold of ($UP_THRESHOLD)."
       DO_SYNC=1
-    fi
   else
     if [ "$RETENTION_DAYS" -gt 0 ]; then
       echo "**WARNING!** Updated files ($UPDATE_COUNT) reached/exceeded threshold ($UP_THRESHOLD)."


### PR DESCRIPTION
bugfix on chk_updated function:
If UP_THRESHOLD is set to 0 on script-config.sh, and on a run there are no updated files (UPDATE_COUNT -eq 0), the if statement on lines 488-490 never triggers, and the script stops processing.  This is because the if statement on line 487 is evaluated and comes out with value false (UPDATE_COUNT being 0 is not less than UP_THRESHOLD also 0). 
This makes the script fail even if there are no updated files, but there are added files.

Example output error below with UP_THRESHOLD=0 set on script-config.sh:

```
SnapRAID DIFF [Mon Jun 3 16:53:10 NZST 2024]
DIFF finished [Mon Jun 3 16:53:14 NZST 2024]
SUMMARY: Equal [145372] - Added [1] - Deleted [0] - Moved [0] - Copied [0] - Updated [0]
There are no deleted files, that's fine.
WARNING! Updated files (0) reached/exceeded threshold (0).
Forced sync is not enabled. Check /tmp/snapRAID.out for details. NOT proceeding with SYNC job. [Mon Jun 3 16:53:14 NZST 2024]
```

Expectation is because there are added files, but 0 updated files, the script should proceed instead of 'NOT proceeding'.

The fixed logic is exactly the same logic used in chk_del function.

