### PR TITLE
Skip trying to install packages if dpkg isn't installed

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -971,7 +971,7 @@ function mklog_noconfig() {
 check_and_install() {
   PACKAGE_NAME=$1
   if [ $(dpkg --version 2>/dev/null | grep -c "Debian") -eq 0 ]; then
-    if [ -z $dpkg_notification ]; then echo "dpkg not found, cannot check for dependencies."; fi
+    if [ -z $dpkg_notification ]; then echo "dpkg not found, cannot check for dependencies. Please ensure they are installed, otherwise the script will not work."; fi
     dpkg_notification=1
   elif [ "$(dpkg-query -W -f='${Status}' $PACKAGE_NAME 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
     echo "$PACKAGE_NAME has not been found and will be installed..."

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -970,7 +970,10 @@ function mklog_noconfig() {
 # Function to check and install packages if not found
 check_and_install() {
   PACKAGE_NAME=$1
-  if [ "$(dpkg-query -W -f='${Status}' $PACKAGE_NAME 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
+  if [ $(dpkg --version 2>/dev/null | grep -c "Debian") -eq 0 ]; then
+    if [ -z $dpkg_notification ]; then echo "dpkg not found, cannot check for dependencies."; fi
+    dpkg_notification=1
+  elif [ "$(dpkg-query -W -f='${Status}' $PACKAGE_NAME 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
     echo "$PACKAGE_NAME has not been found and will be installed..."
     sudo apt-get install -y $PACKAGE_NAME > /dev/null 2>&1
     echo "$PACKAGE_NAME installed successfully."


### PR DESCRIPTION
This PR aims to better handle non-debian based Linux distros.  It does this by just testing the output of `dpkg --version` for the string `Debian`, and assumes if it's present then dpkg is installed and it can be used to install packages, and if it's not present, then it'll just warn the user that it's unable to automatically install packages.

This isn't a perfect system, so I'm very open to feedback, but it does feel like an improvement over the current state.  Right now, the script just assumes `dpkg` is available, and attempts to interpret the output from `dpkg-query` and `apg-get`.  On my openSUSE system this produces this output every time the script runs.
```
## Preprocessing
python3-markdown has not been found and will be installed...
python3-markdown installed successfully.
bc has not been found and will be installed...
bc installed successfully.
curl has not been found and will be installed...
curl installed successfully.
jq has not been found and will be installed...
jq installed successfully.
Healthchecks.io notification is enabled. Notifications sent to https://hc-ping.com/.
```

Even though those packages are installed, and the script is not successfully installing them.  With this change the output changes to.
```
## Preprocessing
dpkg not found, cannot check for dependencies.
Healthchecks.io notification is enabled. Notifications sent to https://hc-ping.com/.
```

Like I said, I'm very open to alternative ways to do this, but this change feels safe, in that at worse it'll behave the same as the current script, as long as the output of `dpkg --version` can be relied upon to produce some text that contains the string `Debian`.