### PR TITLE
Fallback to using sendmail if an incompatible version of mailx is ins…

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -920,8 +920,22 @@ function send_mail(){
     $HOOK_NOTIFICATION "$SUBJECT" "$body"
   elif [ "$EMAIL_ADDRESS" ]; then
     echo -e "Email address is set. Sending email report to **$EMAIL_ADDRESS** [$(date)]"
-    $MAIL_BIN -a 'Content-Type: text/html' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
-      < <(echo "$body")
+    if [ -z "$MAIL_BIN" ]; then
+      echo -e "No mail program set in MAIL_BIN, you must set it to send email."
+    elif [ $(mailx -V | grep -c "12.5 7/5/10") -eq 1 ]; then
+      echo -e "Incompatible version of mailx found, using sendmail instead."
+      (
+        echo To: "$EMAIL_ADDRESS"
+        echo From: "$FROM_EMAIL_ADDRESS"
+        echo "Content-Type: text/html;"
+        echo Subject: "$SUBJECT"
+        echo
+        echo "$body"
+      ) | sendmail -t
+    else
+      $MAIL_BIN -a 'Content-Type: text/html' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
+        < <(echo "$body")
+    fi
   fi
 }
 


### PR DESCRIPTION
…talled

This PR is related to [this issue](https://github.com/auanasgheps/snapraid-aio-script/issues/53).  Annoyingly there are multiple versions of `mailx` out there, with different options available.  The version used in this script uses the `-a` option add a header, but the version I have installed (Heirloom mailx) uses `-a` to add an attachment, and there is no good way to set a header.  [This StackExchange answer](https://unix.stackexchange.com/a/15463/21929) summarizes the situation and options.

The PR looks for the version of `mailx` installed with `mailx -V`, which on my system outputs just `12.5 7/5/10` and nothing more.  On a different system that outputs
```
mailx (GNU Mailutils) 3.5
Copyright (C) 2007-2017 Free Software Foundation, inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

There could be a better way to detect these versions of `mailx`, but this felt safe in that it looks for that one particular string and only does something different if it's present.  Otherwise, it should behave the same as current script.  This will need to be updated if this version of `mailx` is updated to `12.6`, but updates don't seem to happen very often there.

If this incompatible version of `mailx` is found, then we use `sendmail` instead.  From what I found, there is no good way to send HTML emails with the other version of `mailx`, and many people suggest just using `sendmail` instead.