### PR TITLE
fix get_counts() not parsing large diffs

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -430,13 +430,13 @@ function sanity_check() {
 }
 
 function get_counts() {
-  EQ_COUNT=$(grep -w '^ \{1,\}[0-9]* equal' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  ADD_COUNT=$(grep -w '^ \{1,\}[0-9]* added' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  DEL_COUNT=$(grep -w '^ \{1,\}[0-9]* removed' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  UPDATE_COUNT=$(grep -w '^ \{1,\}[0-9]* updated' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  MOVE_COUNT=$(grep -w '^ \{1,\}[0-9]* moved' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  COPY_COUNT=$(grep -w '^ \{1,\}[0-9]* copied' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
-  # REST_COUNT=$(grep -w '^ \{1,\}[0-9]* restored' $TMP_OUTPUT | sed 's/^ *//g' | cut -d ' ' -f1)
+  EQ_COUNT=$(grep -wE '^ *[0-9]+ equal' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
+  ADD_COUNT=$(grep -wE '^ *[0-9]+ added' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
+  DEL_COUNT=$(grep -wE '^ *[0-9]+ removed' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
+  UPDATE_COUNT=$(grep -wE '^ *[0-9]+ updated' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
+  MOVE_COUNT=$(grep -wE '^ *[0-9]+ moved' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
+  COPY_COUNT=$(grep -wE '^ *[0-9]+ copied' "$TMP_OUTPUT" | sed 's/^ *//g' | cut -d ' ' -f1)
+  # REST_COUNT=$(grep -wE '^ *[0-9]+ restored' $TMP_OUTPUT | sed 's/^ *//g' | cut -d ' ' -f1)
 }
 
 function sed_me(){


### PR DESCRIPTION
Difference count numbers longer than 8 digits are not padded with spaces (due to `%8u` formatter):
https://github.com/amadvance/snapraid/blob/c2664c6521aa7df7549a33b4a484427b2ab5f6de/cmdline/scan.c#L1983-L1989

The current regular expression however demands at least one space in front of any difference count number.
This causes `get_counts()` to fail if a single difference count number is longer than 8 digits.

The proposed change with a simplified regular expression does not require a space in front of the number.
It accepts such padding spaces, but does not require them anymore. It does require a number, which always is present.

Here is an example script to highlight the issue:
```
#!/bin/bash
set -o xtrace
echo "  327791 equal" | grep -w '^ \{1,\}[0-9]* equal' | sed 's/^ *//g' | cut -d ' ' -f1
echo "12327791 equal" | grep -w '^ \{1,\}[0-9]* equal' | sed 's/^ *//g' | cut -d ' ' -f1

echo "  327791 equal" | grep -wE '^ *[0-9]+ equal' | sed 's/^ *//g' | cut -d ' ' -f1
echo "12327791 equal" | grep -wE '^ *[0-9]+ equal' | sed 's/^ *//g' | cut -d ' ' -f1
```
```
++ echo '  327791 equal'
++ grep -w '^ \{1,\}[0-9]* equal'
++ sed 's/^ *//g'
++ cut -d ' ' -f1
327791

++ echo '12327791 equal'
++ grep -w '^ \{1,\}[0-9]* equal'
++ sed 's/^ *//g'
++ cut -d ' ' -f1

++ echo '  327791 equal'
++ grep -wE '^ *[0-9]+ equal'
++ sed 's/^ *//g'
++ cut -d ' ' -f1
327791

++ echo '12327791 equal'
++ grep -wE '^ *[0-9]+ equal'
++ sed 's/^ *//g'
++ cut -d ' ' -f1
12327791
```
As you can see in the second execution, the old regular expression is unable to parse the large difference count number.
The large difference count number is no longer padded with spaces, but the old regular expression demands at least one space.
In the fourth execution we can see the new regular expression (not demanding a space), parsing the large number with success.