### PR TITLE
Trim file modified warnings

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -897,7 +897,10 @@ function trim_log(){
     };
     /^### SnapRAID DIFF/,/^\DIFF finished/{
       /^### SnapRAID DIFF/!{/^DIFF finished/!d}
-    }'
+    };
+    /^Unexpected /d;
+    /^WARNING! You cannot modify files during a sync\./d;
+    /^Rerun the sync command when finished\./d'
   }
 
 # Process and mail the email body read from stdin.


### PR DESCRIPTION
Running the SnapRAID script while files are being modified (e.g. BT download) triggers a large number of warnings. When sending an email after the script has finished executing, it will fail due to `Argument list too long` because the content is too long.