### PR TITLE
use snapraid status to check if previous sync was completed

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -8,7 +8,7 @@
 ######################
 #  SCRIPT VARIABLES  #
 ######################
-SNAPSCRIPTVERSION="3.4" #DEV
+SNAPSCRIPTVERSION="3.4" #DEV2
 
 # Read SnapRAID version
 SNAPRAIDVERSION="$(snapraid -V | sed -e 's/snapraid v\(.*\)by.*/\1/')"
@@ -137,26 +137,54 @@ function main(){
   if [ ! -f "$SNAPRAID_CONF" ]; then
   # if running on OMV7, try to find the SnapRAID conf file automatically
   check_omv_version
-  if [ "$OMV_VERSION" -ge 7 ]; then
-  pick_snapraid_conf_file
-  else
-  echo "SnapRAID configuration file not found. The script cannot be run! Please check your settings, because the specified file "$SNAPRAID_CONF" does not exist."
-    mklog "WARN: SnapRAID configuration file not found. The script cannot be run! Please check your settings, because the specified file "$SNAPRAID_CONF" does not exist."
-  SUBJECT="[WARNING] - SnapRAID configuration file not found!"
-    FORMATTED_CONF="\`$SNAPRAID_CONF\`"
-  NOTIFY_OUTPUT="$SUBJECT The script cannot be run! Please check your settings, because the specified file $FORMATTED_CONF does not exist."
-    notify_warning
-    if [ "$EMAIL_ADDRESS" ]; then
-      trim_log < "$TMP_OUTPUT" | send_mail
-    fi
-    exit 1;
-  fi
+    if [ "$OMV_VERSION" -ge 7 ]; then
+	  pick_snapraid_conf_file
+    else
+      echo "SnapRAID configuration file not found. The script cannot be run! Please check your settings, because the specified file "$SNAPRAID_CONF" does not exist."
+      mklog "WARN: SnapRAID configuration file not found. The script cannot be run! Please check your settings, because the specified file "$SNAPRAID_CONF" does not exist."
+      SUBJECT="[WARNING] - SnapRAID configuration file not found!"
+      FORMATTED_CONF="\`$SNAPRAID_CONF\`"
+      NOTIFY_OUTPUT="$SUBJECT The script cannot be run! Please check your settings, because the specified file $FORMATTED_CONF does not exist."
+      notify_warning
+      if [ "$EMAIL_ADDRESS" ]; then
+        trim_log < "$TMP_OUTPUT" | send_mail
+      fi
+      exit 1;
+      fi
   fi
 
 
   # sanity check first to make sure we can access the content and parity files
   mklog "INFO: Checking SnapRAID disks"
   sanity_check
+  
+# Check if previous sync was completed before running a new sync 
+# If the status is ok (exit code 0) the script will proceed, otherwise will stop 
+
+  mklog "INFO: Checking SnapRAID Status"
+  check_snapraid_status
+  if [ $SNAPRAID_STATUS -eq 1 ]; then
+    # Stop the script due to warning
+    echo "Stopping the script because the previous SnapRAID sync did not complete correctly."
+    SUBJECT="[WARNING] - Previous SnapRAID sync did not complete correctly."
+    NOTIFY_OUTPUT="$SUBJECT"
+    notify_warning
+      if [ "$EMAIL_ADDRESS" ]; then
+        trim_log < "$TMP_OUTPUT" | send_mail
+      fi
+    exit 1;
+	
+  elif [ $SNAPRAID_STATUS -eq 2 ]; then
+    # Handle unknown status
+    echo "Stopping the script due to unknown SnapRAID status. Please run 'snapraid status' on your host for more information."
+      SUBJECT="[WARNING] - SnapRAID unknown status"
+      NOTIFY_OUTPUT="$SUBJECT"
+      notify_warning
+      if [ "$EMAIL_ADDRESS" ]; then
+       trim_log < "$TMP_OUTPUT" | send_mail
+      fi
+    exit 1;
+  fi  
 
   # pause configured containers
   if [ "$MANAGE_SERVICES" -eq 1 ]; then
@@ -1104,6 +1132,28 @@ search_conf_files() {
   else
         return 2
     fi
+}
+
+# Run SnapRAID status to check for the previous sync
+check_snapraid_status() {
+  # Run snapraid status command and capture the output
+  local snapraid_status_output=$($SNAPRAID_BIN status)
+
+  # Check for the "No sync is in progress" message
+  if echo "$snapraid_status_output" | grep -q "No sync is in progress"; then
+	echo "Previous sync completed successfully, proceeding."
+	mklog "Previous sync completed successfully, proceeding."
+    SNAPRAID_STATUS=0
+		
+    # Check for the "NOT fully synced" warning message
+  elif echo "$snapraid_status_output" | grep -q "WARNING! The array is NOT fully synced."; then
+	mklog "Warning: The array is NOT fully synced. Stopping the script."
+    SNAPRAID_STATUS=1
+  else 
+    # If neither message is found, handle the unknown state
+	mklog "Warning: The array status is unknown. Stopping the script."
+    SNAPRAID_STATUS=2
+  fi
 }
 
 # Set TRAP


### PR DESCRIPTION
## Description

"snapraid status" initial implementation to verify if the previous sync completed correctly before proceeding, otherwise halt the script.
Fixes #109


Moreover, if this implementation is expanded, could replace some of the checks that the script currently does
- Check if SnapRAID is already running
- Sanity check first to make sure we can access the content and parity files



## Type of change

(Please delete options that are not relevant.)

- [ ] Bug fix or improvement (non-breaking change which fixes an issue, or improvements like code clean-up)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (the maintainer will take care of this)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code (only required for new or big features)
- [x] My changes generate no new warnings
