### PR TITLE
Add the option to execute the last custom hook before spinning down drives

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -226,8 +226,12 @@ BEFORE_HOOK_CMD=""
 # last command.
 # This option does not have any effect if CUSTOM_HOOK is set to 0
 # Use NAME for a friendly name, CMD for the command itself.
+# Set EXECUTE_BEFORE_SPINDOWN to 1, if you have hd-idle configured
+# to spin down your disks in the end and want the custom hook to be
+# executed before that. Default is execution after spindown.
 AFTER_HOOK_NAME=""
 AFTER_HOOK_CMD=""
+EXECUTE_BEFORE_SPINDOWN=0
 
 ####################### USER CONFIGURATION END #######################
 

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -311,6 +311,12 @@ if [ "$SNAP_STATUS" -eq 1 ]; then
    fi
 fi
 
+# Custom Hook - After (if executed before drive spin down)
+if [ "$CUSTOM_HOOK" -eq 1 ] && [ "$EXECUTE_BEFORE_SPINDOWN" -eq 1 ]; then
+	echo "### Custom Hook - [$AFTER_HOOK_NAME]";
+	bash -c "$AFTER_HOOK_CMD"
+fi
+
 # Spin down disks (Method hd-idle - spins down all rotational devices)
 # NOTE: Uses hd-idle rewrite
 
@@ -332,7 +338,7 @@ fi
   fi
 
   # Custom Hook - After
-  if [ "$CUSTOM_HOOK" -eq 1 ]; then
+  if [ "$CUSTOM_HOOK" -eq 1 ] && [ "$EXECUTE_BEFORE_SPINDOWN" -ne 1 ]; then
     echo "### Custom Hook - [$AFTER_HOOK_NAME]";
     bash -c "$AFTER_HOOK_CMD"
   fi


### PR DESCRIPTION
## Description

If hd-idle is configured and the spin-down functionality of the script is activated, the drives are spun down in the end of the script and a possible "custom hook" command is executed after that. Sometimes this command may access the drives in question and it would be preferred to execute the command before spinning down the drives. This PR adds a variable `EXECUTE_BEFORE_SPINDOWN` to the `AFTER_HOOK_CMD` section of the settings. If this variable is set to `1` , the command will be executed right before spinning down the disks instead of after.

(Another option would be to just add a third custom hook, that's executed before the spin-down. This PR already solves my use case though and I don't know if anyone else would use/need such a feature.) 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (the maintainer will take care of this)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code (only required for new or big features)
- [x] My changes generate no new warnings
