### PR TITLE
Add verbosity option 2: Include TOUCH and DIFF output in email (only) if no sync was run because of failed checks (deleted or updated files threshold has been reached or exceeded).

### DIFF
--- a/script-config.sh
+++ b/script-config.sh
@@ -132,11 +132,16 @@ FORCE_ZERO=0
 # hd-idle is required and must be already configured.
 SPINDOWN=0
 
-# Increase verbosity of the email output. NOT RECOMMENDED!
-# If set to 1, TOUCH and DIFF outputs will be kept in the email, producing
-# a mostly unreadable email. You can always check TOUCH and DIFF outputs
-# using the TMP file or use the feature RETENTION_DAYS.
-# 1 to enable, any other value to disable.
+# Increase verbosity of the email output.
+# If set to 2, TOUCH and DIFF outputs will be kept in the email, when the
+# threshold for deleted or updated files has been reached or exceeded and 
+# no sync was run because of that. In all other cases there will be a shorter,
+# more readable email.
+# NOT RECOMMENDED: If set to 1, TOUCH and DIFF outputs will always be kept
+# in the email, producing a mostly unreadable email.
+# You can always check TOUCH and DIFF outputs using the TMP file or use the feature
+# RETENTION_DAYS.
+# Set to any other value than 1 or 2 to disable increased verbosity completely (default)
 VERBOSITY=0
 
 # SnapRAID detailed output retention for each run.

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -361,6 +361,10 @@ fi
     # send long mail if verbosity is set to 1
   if [ "$VERBOSITY" -eq 1 ]; then
       send_mail < "$TMP_OUTPUT"
+		# send a long mail if the sync did not run due to failed checks (deleted or updated files threshold reached or exceeded)
+		# and verbosity is set to 2
+		elif [ "$VERBOSITY" -eq 2 ] && [ "$CHK_FAIL" -eq 1 ] && [ "$DO_SYNC" -eq 0 ]; then
+			send_mail < "$TMP_OUTPUT"
     else
     # or send a short mail
       trim_log < "$TMP_OUTPUT" | send_mail

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -963,7 +963,7 @@ elif [ "$EMAIL_ADDRESS" ]; then
           echo "$body"
         ) | sendmail -t
       else
-        $MAIL_BIN -a 'Content-Type: text/html charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
+        $MAIL_BIN -a 'Content-Type: text/html' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
           < <(echo "$body")
       fi
     fi

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -963,7 +963,7 @@ elif [ "$EMAIL_ADDRESS" ]; then
           echo "$body"
         ) | sendmail -t
       else
-        $MAIL_BIN -a 'Content-Type: text/html; charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
+        $MAIL_BIN -a 'Content-Type: text/html charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
           < <(echo "$body")
       fi
     fi

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -963,7 +963,7 @@ elif [ "$EMAIL_ADDRESS" ]; then
           echo "$body"
         ) | sendmail -t
       else
-        $MAIL_BIN -a 'Content-Type: text/html charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
+        $MAIL_BIN -a 'Content-Type: text/html; charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
           < <(echo "$body")
       fi
     fi

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -963,7 +963,7 @@ elif [ "$EMAIL_ADDRESS" ]; then
           echo "$body"
         ) | sendmail -t
       else
-        $MAIL_BIN -a 'Content-Type: text/html' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
+        $MAIL_BIN -a 'Content-Type: text/html charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
           < <(echo "$body")
       fi
     fi

--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -359,12 +359,12 @@ fi
     # Add a topline to email body and send a long mail
   sed_me "1s:^:##$SUBJECT \n:" "${TMP_OUTPUT}"
     # send long mail if verbosity is set to 1
-  if [ "$VERBOSITY" -eq 1 ]; then
+    if [ "$VERBOSITY" -eq 1 ]; then
       send_mail < "$TMP_OUTPUT"
-		# send a long mail if the sync did not run due to failed checks (deleted or updated files threshold reached or exceeded)
-		# and verbosity is set to 2
-		elif [ "$VERBOSITY" -eq 2 ] && [ "$CHK_FAIL" -eq 1 ] && [ "$DO_SYNC" -eq 0 ]; then
-			send_mail < "$TMP_OUTPUT"
+    # send a long mail if the sync did not run due to failed checks (deleted or updated files threshold reached or exceeded)
+    # and verbosity is set to 2
+    elif [ "$VERBOSITY" -eq 2 ] && [ "$CHK_FAIL" -eq 1 ] && [ "$DO_SYNC" -eq 0 ]; then
+      send_mail < "$TMP_OUTPUT"
     else
     # or send a short mail
       trim_log < "$TMP_OUTPUT" | send_mail


### PR DESCRIPTION
## Description

This adds the option to set `VERBOSITY` to `2`. Setting this will send a mail with the full diff and touch output when the deleted or updated files threshold has been reached or exceeded and no sync was run because of that. It will trim the log in all other cases.
This can be useful if you want to check the list of changed files before running a manual sync every time no automatic sync was run and don't want to bother checking the log via command line.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (the maintainer will take care of this)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code (only required for new or big features)
- [x] My changes generate no new warnings
