### PR TITLE
Set character set for email to UTF-8

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -959,7 +959,7 @@ elif [ "$EMAIL_ADDRESS" ]; then
           echo "$body"
         ) | sendmail -t
       else
-        $MAIL_BIN -a 'Content-Type: text/html' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
+        $MAIL_BIN -a 'Content-Type: text/html; charset=UTF-8' -s "$SUBJECT" -r "$FROM_EMAIL_ADDRESS" "$EMAIL_ADDRESS" \
           < <(echo "$body")
       fi
     fi


### PR DESCRIPTION
Some characters in the email might not be displayed correctly. Setting the charset of the email to utf-8 solves this.

## Description

Some email programs or email providers may not display special characters correctly, if the charset is not specified in the header.
This makes sure emails are always displayed as desired – even if they contain special characters. 

Fixes #122

## Type of change

(Please delete options that are not relevant.)

- [x] Bug fix or improvement (non-breaking change which fixes an issue, or improvements like code clean-up)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code (only required for new or big features)
- [x] My changes generate no new warnings
