### PR TITLE
Update code to build array of content files

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -1275,7 +1275,7 @@ extract_snapraid_info() {
   # Build an array of content files
   CONTENT_FILES=(
     $(echo "$SNAPRAID_CONF_LINES" \
-      | grep snapraid.content \
+      | grep -E '^content ' \
       | cut -d ' ' -f2 \
       | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   )


### PR DESCRIPTION
Will now search for content files based on lines starting with the keyword 'content', instead of occurrence of the filename 'snapraid.content'.

## Description

Please open this PR against the `dev` branch. **Do NOT** use the `master` branch, as I use it only for released code!

Prior logic for finding the snapraid.content files incorrectly included any occurrence of the word "snapraid.content", which could occur in other places in the snapraid.conf file.  Updated with a more robust regex.

Fixes #(issue)

## Type of change

(Please delete options that are not relevant.)

- [X] Bug fix or improvement (non-breaking change which fixes an issue, or improvements like code clean-up)

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code (only required for new or big features)
- [X] My changes generate no new warnings
