### PR TITLE
Email address validity check

### DIFF
--- a/snapraid-aio-script.sh
+++ b/snapraid-aio-script.sh
@@ -75,7 +75,14 @@ main(){
     notify_warning "fatal"
     exit 1;
   fi
-  
+
+  # Validate EMAIL_ADDRESS if set
+  if [ -n "${EMAIL_ADDRESS:-}" ] && ! is_valid_email "$EMAIL_ADDRESS"; then
+    echo "WARNING: EMAIL_ADDRESS is set but invalid: '$EMAIL_ADDRESS'. Email notifications will be disabled."
+    mklog "WARN: EMAIL_ADDRESS is set but invalid. Disabling email notifications."
+	EMAIL_ADDRESS=""
+  fi
+
   # check if sync has been forced by a command argument
   if [ "$FORCE_SYNC" = true ]; then
     SYNC_WARN_THRESHOLD=0
@@ -1479,6 +1486,14 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+}
+
+# Basic email sanity check
+is_valid_email() {
+  local email="$1"
+  [[ -n "$email" ]] || return 1
+  [[ "$email" =~ [[:space:]] ]] && return 1
+  [[ "$email" =~ ^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$ ]]
 }
 
 # Set TRAP


### PR DESCRIPTION
## Description

I decided to remove my email notifications when upgrading to 3.4 and just left that whole section of the config alone, but for some reason emails were still being sent by the script even though my email address was not in the config, only this
```
EMAIL_ADDRESS="destination-email-goes-here"
FROM_EMAIL_ADDRESS="sender-email-goes-here"
```
I created a check to make sure email addresses are in a valid format before doing anything with them, if they are not a warning is written to the logs.

I'm still not sure how emails were making it to me without my address in the script.

## Type of change

- [X] Bug fix or improvement (non-breaking change which fixes an issue, or improvements like code clean-up)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code (only required for new or big features)
- [ ] My changes generate no new warnings
